### PR TITLE
Profile detection + asset stamping + CMS metadata

### DIFF
--- a/pxr/usd/usdProfiles/testenv/testUsdProfilesDetectStamp.py
+++ b/pxr/usd/usdProfiles/testenv/testUsdProfilesDetectStamp.py
@@ -1,0 +1,256 @@
+#!/pxrpythonsubst
+#
+# Copyright 2024 Pixar
+#
+# Licensed under the terms set forth in the LICENSE.txt file available at
+# https://openusd.org/license.
+
+"""Tests for profile detection and asset stamping.
+
+Ref: jensjebens/usd-profiles#16, #17
+"""
+
+from __future__ import print_function
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_PARENT_DIR = os.path.dirname(_SCRIPT_DIR)
+if _PARENT_DIR not in sys.path:
+    sys.path.insert(0, _PARENT_DIR)
+
+from pxr import Usd, UsdGeom, UsdPhysics, UsdProfiles
+
+import usdprofilecheck
+
+
+class TestProfileDetection(unittest.TestCase):
+    """Tests for the detect command."""
+
+    def _make_compliant_stage(self):
+        """Create a stage that passes most SimReady checks."""
+        stage = Usd.Stage.CreateInMemory()
+        stage.SetMetadata("upAxis", "Z")
+        stage.SetMetadata("metersPerUnit", 1.0)
+
+        root = stage.DefinePrim("/Root", "Xform")
+        stage.SetDefaultPrim(root)
+
+        # Geometry
+        geom_scope = stage.DefinePrim("/Root/Geometry", "Scope")
+        mesh = UsdGeom.Mesh.Define(stage, "/Root/Geometry/Body")
+
+        # Physics
+        rb_prim = stage.DefinePrim("/Root/Physics", "Xform")
+        UsdPhysics.RigidBodyAPI.Apply(rb_prim)
+        UsdPhysics.CollisionAPI.Apply(mesh.GetPrim())
+
+        return stage
+
+    def _make_empty_stage(self):
+        """Create a minimal stage with nothing useful."""
+        stage = Usd.Stage.CreateInMemory()
+        stage.DefinePrim("/Root", "Xform")
+        stage.SetDefaultPrim(stage.GetPrimAtPath("/Root"))
+        return stage
+
+    def test_DetectReturnsFeatureResults(self):
+        """detect_profile returns per-feature pass/fail results."""
+        stage = self._make_compliant_stage()
+        result = usdprofilecheck.detect_profile(
+            stage, "com.nvidia.simready.prop_robotics_neutral")
+
+        self.assertIn("features", result)
+        self.assertIsInstance(result["features"], dict)
+
+        # Should have entries for each feature in the profile
+        for feature in ["com.nvidia.simready.geom",
+                        "com.nvidia.simready.physics.rigidBodies",
+                        "com.nvidia.simready.hierarchy",
+                        "com.nvidia.simready.units"]:
+            self.assertIn(feature, result["features"],
+                          f"Expected feature '{feature}' in detection results")
+
+    def test_DetectReportsValidatorCounts(self):
+        """Each feature has validator_count and passed_count."""
+        stage = self._make_compliant_stage()
+        result = usdprofilecheck.detect_profile(
+            stage, "com.nvidia.simready.prop_robotics_neutral")
+
+        for feature_name, feature_result in result["features"].items():
+            self.assertIn("validators", feature_result)
+            self.assertIn("passed", feature_result)
+            self.assertIn("failed", feature_result)
+            self.assertIn("status", feature_result)
+            self.assertIn(feature_result["status"],
+                          ("pass", "partial", "fail"))
+
+    def test_DetectIdentifiesMatchingProfiles(self):
+        """detect_profile reports which profiles the asset matches."""
+        stage = self._make_compliant_stage()
+        result = usdprofilecheck.detect_profile(
+            stage, "com.nvidia.simready.prop_robotics_neutral")
+
+        self.assertIn("profile", result)
+        self.assertIn("compliant", result)
+        self.assertIsInstance(result["compliant"], bool)
+
+    def test_DetectEmptyStageFailsFeatures(self):
+        """An empty stage should fail most features."""
+        stage = self._make_empty_stage()
+        result = usdprofilecheck.detect_profile(
+            stage, "com.nvidia.simready.prop_robotics_neutral")
+
+        self.assertFalse(result["compliant"],
+                         "Empty stage should not be compliant")
+
+    def test_DetectReportsErrors(self):
+        """Failed validators include error details."""
+        stage = self._make_empty_stage()
+        result = usdprofilecheck.detect_profile(
+            stage, "com.nvidia.simready.prop_robotics_neutral")
+
+        # At least some features should have errors
+        has_errors = False
+        for feature_result in result["features"].values():
+            if feature_result.get("errors"):
+                has_errors = True
+                for err in feature_result["errors"]:
+                    self.assertIn("validator", err)
+                    self.assertIn("message", err)
+                break
+        self.assertTrue(has_errors, "Expected some features to have errors")
+
+    def test_DetectJsonOutput(self):
+        """Detection result is JSON-serializable."""
+        stage = self._make_compliant_stage()
+        result = usdprofilecheck.detect_profile(
+            stage, "com.nvidia.simready.prop_robotics_neutral")
+
+        # Should not raise
+        json_str = json.dumps(result, indent=2)
+        parsed = json.loads(json_str)
+        self.assertEqual(parsed["profile"], result["profile"])
+
+
+class TestAssetStamping(unittest.TestCase):
+    """Tests for writing ProfileAPI to assets."""
+
+    def test_StampWritesProfileAPI(self):
+        """stamp_asset applies ProfileAPI and writes profile + capabilities."""
+        stage = Usd.Stage.CreateInMemory()
+        stage.SetMetadata("upAxis", "Z")
+        stage.SetMetadata("metersPerUnit", 1.0)
+        root = stage.DefinePrim("/Root", "Xform")
+        stage.SetDefaultPrim(root)
+
+        profile_id = "com.nvidia.simready.prop_robotics_neutral"
+        capabilities = [
+            "com.nvidia.simready.geom",
+            "com.nvidia.simready.units",
+        ]
+
+        usdprofilecheck.stamp_asset(stage, profile_id, capabilities)
+
+        # Verify ProfileAPI is applied
+        prim = stage.GetDefaultPrim()
+        self.assertTrue(prim.HasAPI(UsdProfiles.ProfileAPI))
+
+        # Verify profile attribute
+        api = UsdProfiles.ProfileAPI(prim)
+        self.assertEqual(api.GetProfileAttr().Get(), profile_id)
+
+        # Verify capabilities
+        caps = list(api.GetCapabilitiesAttr().Get())
+        self.assertEqual(sorted(caps), sorted(capabilities))
+
+    def test_StampRoundTrip(self):
+        """Stamped assets can be read back."""
+        stage = Usd.Stage.CreateInMemory()
+        root = stage.DefinePrim("/Root", "Xform")
+        stage.SetDefaultPrim(root)
+
+        profile_id = "usd.core.v25_05"
+        capabilities = ["usd.core", "usd.geom"]
+
+        usdprofilecheck.stamp_asset(stage, profile_id, capabilities)
+
+        # Read back via queries
+        effective = UsdProfiles.GetEffectiveProfile(root)
+        self.assertEqual(str(effective), profile_id)
+
+    def test_StampToFile(self):
+        """stamp_asset can write to a file on disk."""
+        with tempfile.NamedTemporaryFile(suffix=".usda", delete=False) as f:
+            tmp_path = f.name
+
+        try:
+            stage = Usd.Stage.CreateNew(tmp_path)
+            root = stage.DefinePrim("/Root", "Xform")
+            stage.SetDefaultPrim(root)
+
+            usdprofilecheck.stamp_asset(
+                stage, "usd.core.v25_05", ["usd.core"])
+            stage.GetRootLayer().Save()
+
+            # Reopen and verify
+            stage2 = Usd.Stage.Open(tmp_path)
+            prim = stage2.GetDefaultPrim()
+            self.assertTrue(prim.HasAPI(UsdProfiles.ProfileAPI))
+            api = UsdProfiles.ProfileAPI(prim)
+            self.assertEqual(api.GetProfileAttr().Get(), "usd.core.v25_05")
+        finally:
+            os.unlink(tmp_path)
+
+    def test_StampOnlyPassDoesNotStampFailures(self):
+        """With stamp_only_pass=True, non-compliant assets are not stamped."""
+        stage = Usd.Stage.CreateInMemory()
+        root = stage.DefinePrim("/Root", "Xform")
+        stage.SetDefaultPrim(root)
+
+        # Don't stamp if not compliant
+        result = usdprofilecheck.stamp_asset(
+            stage, "com.nvidia.simready.prop_robotics_neutral", [],
+            stamp_only_pass=True, compliant=False)
+
+        self.assertFalse(result, "Should not stamp non-compliant assets")
+        self.assertFalse(root.HasAPI(UsdProfiles.ProfileAPI))
+
+    def test_MetadataJsonOutput(self):
+        """generate_metadata produces valid JSON with required fields."""
+        metadata = usdprofilecheck.generate_metadata(
+            asset_path="test_asset.usd",
+            profile="com.nvidia.simready.prop_robotics_neutral",
+            compliant=True,
+            features={
+                "com.nvidia.simready.geom": {
+                    "status": "pass",
+                    "validators": 4,
+                    "passed": 4,
+                    "failed": 0,
+                    "errors": [],
+                }
+            },
+            inherited_capabilities=["usd.geom", "usd.core"],
+        )
+
+        # Verify structure
+        self.assertEqual(metadata["asset"], "test_asset.usd")
+        self.assertEqual(metadata["profile"],
+                         "com.nvidia.simready.prop_robotics_neutral")
+        self.assertTrue(metadata["compliant"])
+        self.assertIn("validatedAt", metadata)
+        self.assertIn("features", metadata)
+        self.assertIn("capabilities_inherited", metadata)
+
+        # Should be JSON-serializable
+        json_str = json.dumps(metadata)
+        self.assertIsInstance(json.loads(json_str), dict)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/pxr/usd/usdProfiles/usdprofilecheck.py
+++ b/pxr/usd/usdProfiles/usdprofilecheck.py
@@ -32,6 +32,7 @@ import argparse
 import json
 import sys
 import os
+from datetime import datetime, timezone
 
 # Ensure the usdProfiles module directory is on the path
 _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -161,6 +162,207 @@ def generate_dot_graph(namespace=None, include_predecessors=False):
 
     lines.append('}')
     return '\n'.join(lines)
+
+
+# ─── Profile detection ─────────────────────────────────────────────
+
+def detect_profile(stage, profile_name):
+    """Detect which features of a profile an asset complies with.
+
+    Runs all validators for the given profile, maps errors back to
+    capabilities/features via the DAG, and reports per-feature status.
+
+    Args:
+        stage: An opened Usd.Stage.
+        profile_name: Profile capability id to test against.
+
+    Returns:
+        Dict with structure:
+        {
+            "profile": str,
+            "compliant": bool,
+            "features": {
+                "cap.name": {
+                    "status": "pass" | "partial" | "fail",
+                    "validators": int,
+                    "passed": int,
+                    "failed": int,
+                    "errors": [{"validator": str, "message": str, "site": str}]
+                }
+            },
+            "capabilities_inherited": [str]
+        }
+    """
+    cap_registry = UsdProfiles.CapabilityRegistry.GetInstance()
+    val_registry = UsdValidation.ValidationRegistry()
+
+    if not cap_registry.IsCapability(profile_name):
+        return {
+            "profile": profile_name,
+            "compliant": False,
+            "features": {},
+            "capabilities_inherited": [],
+            "error": f"Unknown profile: {profile_name}",
+        }
+
+    # Get all validators for the profile.
+    all_validator_names = [
+        str(v) for v in cap_registry.GetAllValidatorsForCapability(profile_name)
+    ]
+    validators = val_registry.GetOrLoadValidatorsByName(all_validator_names)
+
+    # Build a map: validator_name → which capability declares it.
+    validator_to_cap = {}
+    predecessors = [profile_name] + [
+        str(p) for p in cap_registry.GetTransitivePredecessors(profile_name)
+    ]
+    for cap_name in predecessors:
+        for v in cap_registry.GetValidators(cap_name):
+            v_str = str(v)
+            if v_str not in validator_to_cap:
+                validator_to_cap[v_str] = cap_name
+
+    # Run validation.
+    ctx = UsdValidation.ValidationContext(validators)
+    errors = ctx.Validate(stage)
+
+    # Map errors to capabilities.
+    errors_by_cap = {}
+    for err in errors:
+        validator = err.GetValidator()
+        if validator:
+            v_name = validator.GetMetadata().name
+            cap = validator_to_cap.get(v_name, "unknown")
+        else:
+            v_name = err.GetIdentifier()
+            cap = "unknown"
+
+        if cap not in errors_by_cap:
+            errors_by_cap[cap] = []
+
+        sites = err.GetSites()
+        site_str = ""
+        if sites:
+            site_prim = sites[0].GetPrim()
+            if site_prim and site_prim.IsValid():
+                site_str = str(site_prim.GetPath())
+
+        errors_by_cap[cap].append({
+            "validator": v_name,
+            "message": err.GetMessage(),
+            "site": site_str,
+            "type": str(err.GetType()),
+        })
+
+    # Determine which validators passed per capability.
+    failed_validators = set()
+    for err in errors:
+        validator = err.GetValidator()
+        if validator:
+            failed_validators.add(validator.GetMetadata().name)
+
+    # Build per-feature results.
+    # "Features" are direct predecessor capabilities of the profile
+    # (plus their sub-capabilities). We report on each capability that
+    # has validators.
+    features = {}
+    for cap_name in predecessors:
+        cap_validators = [str(v) for v in cap_registry.GetValidators(cap_name)]
+        if not cap_validators:
+            continue  # Skip namespace-only nodes
+
+        passed = [v for v in cap_validators if v not in failed_validators]
+        failed = [v for v in cap_validators if v in failed_validators]
+
+        if len(failed) == 0:
+            status = "pass"
+        elif len(passed) == 0:
+            status = "fail"
+        else:
+            status = "partial"
+
+        features[cap_name] = {
+            "status": status,
+            "validators": len(cap_validators),
+            "passed": len(passed),
+            "failed": len(failed),
+            "errors": errors_by_cap.get(cap_name, []),
+        }
+
+    # Overall compliance: all features must pass.
+    compliant = all(f["status"] == "pass" for f in features.values())
+
+    # Inherited capabilities (usd.* bridge nodes).
+    inherited = [
+        cap for cap in predecessors
+        if cap.startswith("usd.") and cap != "usd"
+        and len(cap_registry.GetValidators(cap)) > 0
+    ]
+
+    return {
+        "profile": profile_name,
+        "compliant": compliant,
+        "features": features,
+        "capabilities_inherited": inherited,
+    }
+
+
+# ─── Asset stamping ───────────────────────────────────────────────
+
+def stamp_asset(stage, profile_id, capabilities, stamp_only_pass=False,
+                compliant=True):
+    """Write ProfileAPI to the stage's default prim.
+
+    Args:
+        stage: An opened Usd.Stage (must be editable).
+        profile_id: Profile string to write.
+        capabilities: List of capability strings to write.
+        stamp_only_pass: If True, only stamp if compliant is True.
+        compliant: Whether the asset passed validation.
+
+    Returns:
+        True if the asset was stamped, False if skipped.
+    """
+    if stamp_only_pass and not compliant:
+        return False
+
+    prim = stage.GetDefaultPrim()
+    if not prim or not prim.IsValid():
+        return False
+
+    api = UsdProfiles.ProfileAPI.Apply(prim)
+    api.GetProfileAttr().Set(profile_id)
+    if capabilities:
+        api.GetCapabilitiesAttr().Set(capabilities)
+
+    return True
+
+
+def generate_metadata(asset_path, profile, compliant, features,
+                      inherited_capabilities, errors=None):
+    """Generate CMS-compatible JSON metadata for a validation result.
+
+    Args:
+        asset_path: Path to the validated asset.
+        profile: Profile id that was validated against.
+        compliant: Whether the asset passed.
+        features: Dict of per-feature results.
+        inherited_capabilities: List of inherited usd.* capabilities.
+        errors: Optional list of top-level errors.
+
+    Returns:
+        Dict suitable for JSON serialization.
+    """
+    return {
+        "schema": "usd-profiles/validation-metadata/v1",
+        "asset": asset_path,
+        "profile": profile,
+        "compliant": compliant,
+        "validatedAt": datetime.now(timezone.utc).isoformat(),
+        "features": features,
+        "capabilities_inherited": inherited_capabilities,
+        "errors": errors or [],
+    }
 
 
 def _get_profile_for_stage(stage):
@@ -393,6 +595,156 @@ def cmd_graph(args):
     return 0
 
 
+def cmd_detect(args):
+    """Detect which features/profiles an asset complies with."""
+    _register_validators()
+
+    all_results = []
+    exit_code = 0
+
+    for asset_path in args.assets:
+        stage = Usd.Stage.Open(asset_path)
+        if not stage:
+            print(f"ERROR: Cannot open {asset_path}", file=sys.stderr)
+            exit_code = 1
+            continue
+
+        # Determine which profile(s) to test against.
+        if args.profile:
+            profiles_to_test = [args.profile]
+        else:
+            # Test against all registered profiles.
+            cap_registry = UsdProfiles.CapabilityRegistry.GetInstance()
+            profiles_to_test = sorted(
+                str(p) for p in cap_registry.GetAllProfiles())
+
+        for profile in profiles_to_test:
+            result = detect_profile(stage, profile)
+            result["asset"] = asset_path
+            all_results.append(result)
+
+    # Output
+    if args.format == "json":
+        json.dump(all_results, sys.stdout, indent=2)
+        print()
+    else:
+        for r in all_results:
+            print(f"\n{'='*70}")
+            print(f"Asset:   {r.get('asset', '?')}")
+            print(f"Profile: {r['profile']}")
+            status = "✅ COMPLIANT" if r["compliant"] else "❌ NON-COMPLIANT"
+            print(f"Result:  {status}")
+            print(f"{'─'*70}")
+
+            for feat_name, feat in sorted(r["features"].items()):
+                if feat["status"] == "pass":
+                    icon = "✅"
+                elif feat["status"] == "partial":
+                    icon = "⚠️ "
+                else:
+                    icon = "❌"
+                print(f"  {icon} {feat_name} "
+                      f"({feat['passed']}/{feat['validators']} validators)")
+                for err in feat.get("errors", []):
+                    print(f"      ✗ [{err['validator']}] {err['message'][:80]}")
+                    if err.get("site"):
+                        print(f"        at {err['site']}")
+
+            if r.get("capabilities_inherited"):
+                print(f"\n  Inherited (via usd.* bridge):")
+                for cap in r["capabilities_inherited"]:
+                    print(f"    ← {cap}")
+
+    return exit_code
+
+
+def cmd_validate_with_stamp(args):
+    """Extended validate that supports --stamp and --metadata."""
+    _register_validators()
+
+    all_results = []
+    all_metadata = []
+    exit_code = 0
+
+    for asset_path in args.assets:
+        stage = Usd.Stage.Open(asset_path)
+        if not stage:
+            print(f"ERROR: Cannot open {asset_path}", file=sys.stderr)
+            exit_code = 1
+            continue
+
+        profile = args.profile
+        if not profile:
+            profile = _get_profile_for_stage(stage)
+            if not profile:
+                print(f"SKIP: {asset_path} — no profile "
+                      "(use --profile to specify)", file=sys.stderr)
+                continue
+
+        result = detect_profile(stage, profile)
+        result["asset"] = asset_path
+        all_results.append(result)
+
+        if not result["compliant"]:
+            exit_code = 1
+
+        # Stamp if requested.
+        if args.stamp:
+            satisfied_caps = [
+                name for name, feat in result["features"].items()
+                if feat["status"] == "pass"
+            ]
+            stamped = stamp_asset(
+                stage, profile, satisfied_caps,
+                stamp_only_pass=args.stamp_only_pass,
+                compliant=result["compliant"],
+            )
+            if stamped:
+                stage.GetRootLayer().Save()
+                if args.format == "text":
+                    print(f"  📝 Stamped {asset_path}")
+
+        # Metadata if requested.
+        if args.metadata:
+            meta = generate_metadata(
+                asset_path=asset_path,
+                profile=profile,
+                compliant=result["compliant"],
+                features=result["features"],
+                inherited_capabilities=result.get(
+                    "capabilities_inherited", []),
+            )
+            all_metadata.append(meta)
+
+    # Output
+    if args.metadata and args.format == "json":
+        json.dump(all_metadata, sys.stdout, indent=2)
+        print()
+    elif args.format == "json":
+        json.dump(all_results, sys.stdout, indent=2)
+        print()
+    elif args.metadata:
+        json.dump(all_metadata, sys.stdout, indent=2)
+        print()
+    else:
+        for r in all_results:
+            print(f"\n{'='*70}")
+            print(f"Asset:   {r.get('asset', '?')}")
+            print(f"Profile: {r['profile']}")
+            status = "✅ COMPLIANT" if r["compliant"] else "❌ NON-COMPLIANT"
+            print(f"Result:  {status}")
+
+            for feat_name, feat in sorted(r["features"].items()):
+                icon = "✅" if feat["status"] == "pass" else (
+                    "⚠️ " if feat["status"] == "partial" else "❌")
+                print(f"  {icon} {feat_name} "
+                      f"({feat['passed']}/{feat['validators']})")
+                for err in feat.get("errors", []):
+                    print(f"      ✗ {err['message'][:80]}")
+
+    return exit_code
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="usdprofilecheck",
@@ -414,10 +766,28 @@ def main():
                                 help="Profile to validate against (default: read from asset)")
     validate_parser.add_argument("--strict", "-s", action="store_true",
                                 help="Treat warnings as errors")
+    validate_parser.add_argument("--stamp", action="store_true",
+                                help="Write ProfileAPI to the asset after validation")
+    validate_parser.add_argument("--stamp-only-pass", action="store_true",
+                                help="Only stamp if the asset is compliant")
+    validate_parser.add_argument("--metadata", action="store_true",
+                                help="Output JSON metadata for CMS systems")
     validate_parser.add_argument("--format",
                                 choices=["text", "json", "csv"],
                                 default="text",
                                 help="Output format (default: text)")
+
+    # detect
+    detect_parser = subparsers.add_parser("detect",
+                                          help="Detect which profiles an asset complies with")
+    detect_parser.add_argument("assets", nargs="+",
+                               help="USD asset path(s) to analyze")
+    detect_parser.add_argument("--profile", "-p",
+                               help="Test against a specific profile (default: all profiles)")
+    detect_parser.add_argument("--format",
+                               choices=["text", "json"],
+                               default="text",
+                               help="Output format (default: text)")
 
     # list-profiles
     lp = subparsers.add_parser("list-profiles", help="List available profiles")
@@ -443,8 +813,8 @@ def main():
     gp.add_argument("-o", "--output",
                     help="Write DOT to file instead of stdout")
 
-    SUBCOMMANDS = ("validate", "list-profiles", "list-capabilities", "graph",
-                   "-h", "--help")
+    SUBCOMMANDS = ("validate", "detect", "list-profiles", "list-capabilities",
+                   "graph", "-h", "--help")
 
     # If first arg doesn't match a subcommand, assume validate
     if len(sys.argv) > 1 and sys.argv[1] not in SUBCOMMANDS:
@@ -453,7 +823,11 @@ def main():
     args = parser.parse_args()
 
     if args.command == "validate":
+        if hasattr(args, 'stamp') and (args.stamp or args.metadata):
+            return cmd_validate_with_stamp(args)
         return cmd_validate(args)
+    elif args.command == "detect":
+        return cmd_detect(args)
     elif args.command == "list-profiles":
         return cmd_list_profiles(args)
     elif args.command == "list-capabilities":


### PR DESCRIPTION
## Summary

Two new features for `usdprofilecheck`:

### 1. `detect` — Profile detection (#16)

Given an undecorated asset, figure out which features it complies with:

```bash
usdprofilecheck detect --profile com.nvidia.simready.prop_robotics_neutral apple.usd
```

```
Asset:   apple.usd
Profile: com.nvidia.simready.prop_robotics_neutral
Result:  ❌ NON-COMPLIANT
──────────────────────────────────────────────────
  ⚠️  com.nvidia.simready.geom (3/4 validators)
      ✗ [VG.MESH.001] BasisCurves, not a Mesh
  ✅ com.nvidia.simready.hierarchy (2/2)
  ⚠️  com.nvidia.simready.physics.rigidBodies (2/3)
      ✗ [RB.COL.001] Missing CollisionAPI
  ✅ com.nvidia.simready.units (1/1)
  ✅ usd.core (3/3)
  ✅ usd.geom (4/4)
  ✅ usd.physics (4/4)
```

JSON output for CI: `--format json`

### 2. `validate --stamp` — Asset stamping (#17)

Write ProfileAPI into the asset after validation:

```bash
# Stamp the asset
usdprofilecheck validate --profile <profile> --stamp asset.usd

# Only stamp if compliant
usdprofilecheck validate --profile <profile> --stamp --stamp-only-pass asset.usd

# Output JSON metadata for CMS
usdprofilecheck validate --profile <profile> --metadata --format json asset.usd
```

CMS JSON output includes per-feature breakdown, inherited capabilities, validation timestamp, and schema version.

### API

- `detect_profile(stage, profile_name)` → dict with per-feature pass/partial/fail
- `stamp_asset(stage, profile_id, capabilities)` → bool
- `generate_metadata(...)` → CMS-compatible dict

### Tests

11 new tests — all passing ✅

Tested against SimReady Foundation assets (apple, toolbox, UR10).

Ref: jensjebens/usd-profiles#16, jensjebens/usd-profiles#17