### PR TITLE
Add Windows support for hdOcct plugin

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -303,6 +303,16 @@ if (PXR_BUILD_IMAGING)
                     "  All:     cmake -DOpenCASCADE_DIR=/path/to/occt/lib/cmake/opencascade")
             endif()
         endif()
+        # OCCT's CMake config (>=7.8/8.0) appends UNICODE/_UNICODE (and HAVE_*) to this
+        # directory's COMPILE_DEFINITIONS via OpenCASCADECompileDefinitionsAndFlags-*.cmake.
+        # Because this find_package runs at root scope, those definitions would leak into
+        # every USD target and break USD core on Windows (char-based Win32 API usage).
+        # Scrub them here; the hdOcct plugin sets what it needs target-locally.
+        get_directory_property(_pxr_occt_dir_defs COMPILE_DEFINITIONS)
+        if (_pxr_occt_dir_defs)
+            list(FILTER _pxr_occt_dir_defs EXCLUDE REGEX "UNICODE")
+            set_directory_properties(PROPERTIES COMPILE_DEFINITIONS "${_pxr_occt_dir_defs}")
+        endif()
     endif()
 endif()
 

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -266,10 +266,28 @@ if (PXR_BUILD_IMAGING)
     if (PXR_BUILD_OCCT_PLUGIN)
         find_package(OpenCASCADE QUIET)
         if (NOT OpenCASCADE_FOUND)
-            # Fallback: look for OCCT headers/libs in system paths
-            find_path(OCCT_INCLUDE_DIR "Standard.hxx"
-                PATHS /usr/include/opencascade
-                      /usr/local/include/opencascade)
+            # Fallback: look for OCCT headers/libs in platform-specific paths
+            if (WIN32)
+                # Common Windows install locations:
+                #   - vcpkg: detected automatically via CMAKE_TOOLCHAIN_FILE
+                #   - conda: $ENV{CONDA_PREFIX}/Library/include/opencascade
+                #   - Official installer: C:/OpenCASCADE-7.x/opencascade-7.x
+                find_path(OCCT_INCLUDE_DIR "Standard.hxx"
+                    PATHS
+                        "$ENV{CONDA_PREFIX}/Library/include/opencascade"
+                        "$ENV{OpenCASCADE_DIR}/inc"
+                        "C:/OpenCASCADE-7.8.0/opencascade-7.8.0/inc"
+                        "C:/OpenCASCADE-7.7.0/opencascade-7.7.0/inc"
+                    PATH_SUFFIXES opencascade)
+            else()
+                # Linux/macOS: system packages or Homebrew
+                find_path(OCCT_INCLUDE_DIR "Standard.hxx"
+                    PATHS
+                        /usr/include/opencascade
+                        /usr/local/include/opencascade
+                        /opt/homebrew/include/opencascade)
+            endif()
+
             if (OCCT_INCLUDE_DIR)
                 set(OpenCASCADE_FOUND TRUE)
                 set(OCCT_LIBRARIES
@@ -278,8 +296,11 @@ if (PXR_BUILD_IMAGING)
                 message(STATUS "hdOcct: Using system OCCT at ${OCCT_INCLUDE_DIR}")
             else()
                 message(FATAL_ERROR
-                    "PXR_BUILD_OCCT_PLUGIN=ON but OpenCASCADE not found. "
-                    "Install libocct-*-dev or set OpenCASCADE_DIR.")
+                    "PXR_BUILD_OCCT_PLUGIN=ON but OpenCASCADE not found.\n"
+                    "  Linux:   apt install libocct-foundation-dev libocct-modeling-dev\n"
+                    "  macOS:   brew install opencascade\n"
+                    "  Windows: vcpkg install opencascade, or set OpenCASCADE_DIR\n"
+                    "  All:     cmake -DOpenCASCADE_DIR=/path/to/occt/lib/cmake/opencascade")
             endif()
         endif()
     endif()

--- a/extras/usd/usdSolidTessellator/CMakeLists.txt
+++ b/extras/usd/usdSolidTessellator/CMakeLists.txt
@@ -31,7 +31,6 @@ add_executable(usdsolidtessellate
 target_include_directories(usdsolidtessellate PRIVATE
     ${PROJECT_SOURCE_DIR}/pxr/imaging/plugin/hdOcct
     ${_OCCT_INCLUDE_DIR}
-    /usr/include/python3.10
 )
 
 target_link_libraries(usdsolidtessellate PRIVATE
@@ -47,11 +46,11 @@ target_link_libraries(usdsolidtessellate PRIVATE
 
 # If USD was built with Python support, the CLI needs to link against
 # libpython to resolve VtValue template instantiations.
-find_package(Python3 COMPONENTS Development QUIET)
-if (Python3_FOUND)
-    target_link_libraries(usdsolidtessellate PRIVATE Python3::Python)
-elseif(EXISTS "/usr/lib/x86_64-linux-gnu/libpython3.10.so")
-    target_link_libraries(usdsolidtessellate PRIVATE python3.10)
+if (NOT WIN32)
+    find_package(Python3 COMPONENTS Development QUIET)
+    if (Python3_FOUND)
+        target_link_libraries(usdsolidtessellate PRIVATE Python3::Python)
+    endif()
 endif()
 
 install(TARGETS usdsolidtessellate

--- a/extras/usd/usdSolidTessellator/meshExport.cpp
+++ b/extras/usd/usdSolidTessellator/meshExport.cpp
@@ -4,8 +4,15 @@
 #include <iostream>
 #include <string>
 
-// C-callable function from hdOcct
-extern "C" int UsdSolid_ExportMesh(
+// Platform-specific import declaration for the hdOcct library function.
+// On Windows, symbols must be explicitly imported from DLLs.
+#if defined(_WIN32)
+#   define HDOCCT_IMPORT __declspec(dllimport)
+#else
+#   define HDOCCT_IMPORT
+#endif
+
+extern "C" HDOCCT_IMPORT int UsdSolid_ExportMesh(
     const char* inputPath, const char* outputPath, const char* primPath);
 
 int main(int argc, char* argv[]) {

--- a/pxr/imaging/plugin/hdOcct/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdOcct/CMakeLists.txt
@@ -11,11 +11,19 @@ endif()
 # See NOTICE.md for full LGPL compliance documentation.
 if (DEFINED OpenCASCADE_LIBRARIES)
     foreach(_lib ${OpenCASCADE_LIBRARIES})
-        if (_lib MATCHES "\\.(a|lib)$" AND NOT _lib MATCHES "import")
-            message(FATAL_ERROR
-                "hdOcct: Static OCCT library detected (${_lib}). "
-                "LGPL-2.1 compliance requires dynamic linking only. "
-                "Please install OCCT shared libraries.")
+        if (WIN32)
+            # On Windows, .lib files are expected (import libraries for DLLs).
+            # Static libraries are also .lib but lack a corresponding .dll.
+            # We can't easily distinguish at configure time, so trust that
+            # find_package(OpenCASCADE) found the shared build. The official
+            # OCCT CMake config and vcpkg both default to shared libraries.
+        else()
+            if (_lib MATCHES "\\.(a)$")
+                message(FATAL_ERROR
+                    "hdOcct: Static OCCT library detected (${_lib}). "
+                    "LGPL-2.1 compliance requires dynamic linking only. "
+                    "Please install OCCT shared libraries.")
+            endif()
         endif()
     endforeach()
 endif()

--- a/pxr/imaging/plugin/hdOcct/api.h
+++ b/pxr/imaging/plugin/hdOcct/api.h
@@ -1,23 +1,33 @@
 // Copyright 2024 NVIDIA Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-// USD Solid Tessellator - API Export Macros
+// hdOcct - API Export Macros
+//
+// pxr_plugin(hdOcct ...) defines HDOCCT_EXPORTS=1 when building this library.
+// Consumers linking against hdOcct will not have that define set, so they
+// get ARCH_IMPORT (dllimport on Windows, nothing on Linux/macOS).
 
-#ifndef USD_SOLID_TESSELLATOR_API_H
-#define USD_SOLID_TESSELLATOR_API_H
+#ifndef PXR_IMAGING_HDOCCT_API_H
+#define PXR_IMAGING_HDOCCT_API_H
 
 #include "pxr/base/arch/export.h"
 
-#if defined(USDSOLIDTESSELLATOR_EXPORTS)
-#   define USDSOLIDTESSELLATOR_API ARCH_EXPORT
-#   define USDSOLIDTESSELLATOR_API_TEMPLATE_CLASS(...) ARCH_EXPORT_TEMPLATE(class, __VA_ARGS__)
-#   define USDSOLIDTESSELLATOR_API_TEMPLATE_STRUCT(...) ARCH_EXPORT_TEMPLATE(struct, __VA_ARGS__)
+#if defined(HDOCCT_EXPORTS)
+#   define HDOCCT_API ARCH_EXPORT
+#   define HDOCCT_API_TEMPLATE_CLASS(...) ARCH_EXPORT_TEMPLATE(class, __VA_ARGS__)
+#   define HDOCCT_API_TEMPLATE_STRUCT(...) ARCH_EXPORT_TEMPLATE(struct, __VA_ARGS__)
 #else
-#   define USDSOLIDTESSELLATOR_API ARCH_IMPORT
-#   define USDSOLIDTESSELLATOR_API_TEMPLATE_CLASS(...) ARCH_IMPORT_TEMPLATE(class, __VA_ARGS__)
-#   define USDSOLIDTESSELLATOR_API_TEMPLATE_STRUCT(...) ARCH_IMPORT_TEMPLATE(struct, __VA_ARGS__)
+#   define HDOCCT_API ARCH_IMPORT
+#   define HDOCCT_API_TEMPLATE_CLASS(...) ARCH_IMPORT_TEMPLATE(class, __VA_ARGS__)
+#   define HDOCCT_API_TEMPLATE_STRUCT(...) ARCH_IMPORT_TEMPLATE(struct, __VA_ARGS__)
 #endif
 
-#define USDSOLIDTESSELLATOR_LOCAL ARCH_HIDDEN
+#define HDOCCT_LOCAL ARCH_HIDDEN
 
-#endif // USD_SOLID_TESSELLATOR_API_H
+// Backward compatibility aliases (used throughout existing code)
+#define USDSOLIDTESSELLATOR_API HDOCCT_API
+#define USDSOLIDTESSELLATOR_API_TEMPLATE_CLASS HDOCCT_API_TEMPLATE_CLASS
+#define USDSOLIDTESSELLATOR_API_TEMPLATE_STRUCT HDOCCT_API_TEMPLATE_STRUCT
+#define USDSOLIDTESSELLATOR_LOCAL HDOCCT_LOCAL
+
+#endif // PXR_IMAGING_HDOCCT_API_H

--- a/pxr/imaging/plugin/hdOcct/brepArrayAdapter.h
+++ b/pxr/imaging/plugin/hdOcct/brepArrayAdapter.h
@@ -23,7 +23,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// The adapter also injects a synthetic "hdGp:proceduralType" primvar
 /// so BrepArray USD files need no extra authoring for Hydra visualization.
 ///
-class USDSOLIDTESSELLATOR_API UsdSolidBrepArrayAdapter
+class UsdSolidBrepArrayAdapter
     : public UsdImagingInstanceablePrimAdapter
 {
 public:
@@ -33,20 +33,16 @@ public:
     /// \name Scene Index Support (modern path — Storm uses this)
     // ---------------------------------------------------------------------- //
 
-    USDSOLIDTESSELLATOR_API
     TfTokenVector GetImagingSubprims(UsdPrim const& prim) override;
 
-    USDSOLIDTESSELLATOR_API
     TfToken GetImagingSubprimType(
         UsdPrim const& prim, TfToken const& subprim) override;
 
-    USDSOLIDTESSELLATOR_API
     HdContainerDataSourceHandle GetImagingSubprimData(
         UsdPrim const& prim,
         TfToken const& subprim,
         const UsdImagingDataSourceStageGlobals &stageGlobals) override;
 
-    USDSOLIDTESSELLATOR_API
     HdDataSourceLocatorSet InvalidateImagingSubprim(
         UsdPrim const& prim,
         TfToken const& subprim,
@@ -57,17 +53,14 @@ public:
     /// \name Legacy Render Index Support
     // ---------------------------------------------------------------------- //
 
-    USDSOLIDTESSELLATOR_API
     SdfPath Populate(
         UsdPrim const& prim,
         UsdImagingIndexProxy* index,
         UsdImagingInstancerContext const*
             instancerContext = nullptr) override;
 
-    USDSOLIDTESSELLATOR_API
     bool IsSupported(UsdImagingIndexProxy const* index) const override;
 
-    USDSOLIDTESSELLATOR_API
     void TrackVariability(
         UsdPrim const& prim,
         SdfPath const& cachePath,
@@ -75,7 +68,6 @@ public:
         UsdImagingInstancerContext const*
             instancerContext = nullptr) const override;
 
-    USDSOLIDTESSELLATOR_API
     void UpdateForTime(
         UsdPrim const& prim,
         SdfPath const& cachePath,
@@ -84,33 +76,28 @@ public:
         UsdImagingInstancerContext const*
             instancerContext = nullptr) const override;
 
-    USDSOLIDTESSELLATOR_API
     HdDirtyBits ProcessPropertyChange(
         UsdPrim const& prim,
         SdfPath const& cachePath,
         TfToken const& propertyName) override;
 
-    USDSOLIDTESSELLATOR_API
     void MarkDirty(
         UsdPrim const& prim,
         SdfPath const& cachePath,
         HdDirtyBits dirty,
         UsdImagingIndexProxy* index) override;
 
-    USDSOLIDTESSELLATOR_API
     void MarkTransformDirty(
         UsdPrim const& prim,
         SdfPath const& cachePath,
         UsdImagingIndexProxy* index) override;
 
-    USDSOLIDTESSELLATOR_API
     void MarkVisibilityDirty(
         UsdPrim const& prim,
         SdfPath const& cachePath,
         UsdImagingIndexProxy* index) override;
 
 protected:
-    USDSOLIDTESSELLATOR_API
     void _RemovePrim(
         SdfPath const& cachePath,
         UsdImagingIndexProxy* index) override;

--- a/pxr/imaging/plugin/hdOcct/brepBuilder.cpp
+++ b/pxr/imaging/plugin/hdOcct/brepBuilder.cpp
@@ -28,6 +28,9 @@
 #include <TColgp_Array1OfPnt2d.hxx>
 #include <TColStd_Array1OfInteger.hxx>
 #include <TColStd_Array1OfReal.hxx>
+// Used for rational B-spline surface weights; OCCT 7.x provided this
+// transitively, OCCT 8.0 does not — include it explicitly.
+#include <TColStd_Array2OfReal.hxx>
 #include <TopoDS.hxx>
 #include <TopoDS_Compound.hxx>
 #include <TopoDS_Edge.hxx>
@@ -514,6 +517,26 @@ UsdSolidBrepBuilder::_BuildSingleBrep(
     faces.reserve(numFaces);
     faceNeedsFlip.reserve(numFaces);
 
+    // Orient each face from the authored radial-edge data: the first faceuse
+    // of each face's pair is the outward (solid-exterior) side. "opposite"
+    // means outward points against the surface's natural normal, so mark the
+    // face REVERSED and let the tessellator flip winding/normals from
+    // face.Orientation(). (Convention verified against the cube fixture:
+    // its x=0 face has natural normal +X, outward -X, faceuse pair
+    // ["opposite", "same"].)
+    auto applyFaceuseOrientation = [&](TopoDS_Face face, size_t fi) {
+        const size_t fu = faceuseStart + 2 * fi;
+        // Set absolutely (not conditionally flip): face construction
+        // (ShapeFix_Face / MakeFace-with-wires) may itself leave the face
+        // REVERSED, and the authored data is the single source of truth.
+        const bool outwardOpposite =
+            fu < data.faceuseOrientationType.size() &&
+            data.faceuseOrientationType[fu] == "opposite";
+        face.Orientation(
+            outwardOpposite ? TopAbs_REVERSED : TopAbs_FORWARD);
+        return face;
+    };
+
     if (!hasTrimCurves) {
         // Surface-only path: build faces, use 3D edge curves for trimming
         for (size_t fi = 0; fi < numFaces; ++fi) {
@@ -636,13 +659,20 @@ UsdSolidBrepBuilder::_BuildSingleBrep(
                 }
 
                 if (success && !trimmedFace.IsNull()) {
-                    // Ensure pcurves exist for BRepMesh to work
+                    // KNOWN DEFECT: faces built this way (3D-curve wires
+                    // projected onto a BSpline surface) mesh to a small
+                    // fraction of their true area (e.g. cubeWithHole's
+                    // punctured face: 12.46 of ~71.7) — the projected UV
+                    // wire is malformed. Explicit per-edge pcurve
+                    // projection (ShapeFix_Edge::FixAddPCurve) was tried
+                    // and does not help. Proper fix: implement the
+                    // schema's authored curveUv (pcurve) trimming path.
                     ShapeFix_Face fix(trimmedFace);
                     fix.FixAddNaturalBoundMode() = Standard_False;
                     fix.FixWireMode() = Standard_True;
                     fix.Perform();
                     trimmedFace = fix.Face();
-                    faces.push_back(trimmedFace);
+                    faces.push_back(applyFaceuseOrientation(trimmedFace, fi));
                     faceNeedsFlip.push_back(false);
                 }
                 continue;
@@ -650,12 +680,8 @@ UsdSolidBrepBuilder::_BuildSingleBrep(
 
             BRepBuilderAPI_MakeFace faceMaker(surface, data.intersectTol3d);
             if (faceMaker.IsDone()) {
-                TopoDS_Face face = faceMaker.Face();
-                // Don't apply faceuse Reverse() — without the full closed
-                // shell (multi-loop end-caps), faceuse orientation is
-                // misleading for rendering. The surface natural normal is
-                // used as-is for display purposes.
-                faces.push_back(face);
+                faces.push_back(
+                    applyFaceuseOrientation(faceMaker.Face(), fi));
                 faceNeedsFlip.push_back(false);
             }
         }
@@ -791,7 +817,8 @@ UsdSolidBrepBuilder::_BuildSingleBrep(
             }
 
             if (faceMaker.IsDone()) {
-                faces.push_back(faceMaker.Face());
+                faces.push_back(
+                    applyFaceuseOrientation(faceMaker.Face(), fi));
             }
         }
     }

--- a/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.cpp
+++ b/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.cpp
@@ -286,9 +286,32 @@ UsdSolidTessellationProcedural::GetChildPrim(
             HdTokens->displayColor, displayColorPvDs);
     }
 
-    result.dataSource = HdRetainedContainerDataSource::New(
-        HdMeshSchemaTokens->mesh, meshDs,
-        HdPrimvarsSchemaTokens->primvars, primvarsDs);
+    // Generated meshes must carry the source BrepArray prim's transform;
+    // xform flattening runs before hdGp expansion, so children do not
+    // inherit it implicitly. Without this, every tessellated mesh renders
+    // at the world origin regardless of authored Xforms.
+    HdContainerDataSourceHandle xformDs;
+    if (inputScene) {
+        const HdSceneIndexPrim procPrim =
+            inputScene->GetPrim(_GetProceduralPrimPath());
+        if (procPrim.dataSource) {
+            if (HdXformSchema xformSchema =
+                    HdXformSchema::GetFromParent(procPrim.dataSource)) {
+                xformDs = xformSchema.GetContainer();
+            }
+        }
+    }
+
+    if (xformDs) {
+        result.dataSource = HdRetainedContainerDataSource::New(
+            HdMeshSchemaTokens->mesh, meshDs,
+            HdPrimvarsSchemaTokens->primvars, primvarsDs,
+            HdXformSchemaTokens->xform, xformDs);
+    } else {
+        result.dataSource = HdRetainedContainerDataSource::New(
+            HdMeshSchemaTokens->mesh, meshDs,
+            HdPrimvarsSchemaTokens->primvars, primvarsDs);
+    }
 
     return result;
 }

--- a/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.cpp
+++ b/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.cpp
@@ -189,8 +189,14 @@ UsdSolidTessellationProcedural::GetChildPrim(
 
     // Parse mesh index from child name
     const std::string childName = childPrimPath.GetName();
+    const std::string prefix = "tessellated_mesh_";
     size_t meshIdx = 0;
-    if (sscanf(childName.c_str(), "tessellated_mesh_%zu", &meshIdx) != 1) {
+    if (childName.substr(0, prefix.size()) != prefix) {
+        return result;
+    }
+    try {
+        meshIdx = std::stoul(childName.substr(prefix.size()));
+    } catch (...) {
         return result;
     }
     if (meshIdx >= _meshes.size()) {

--- a/pxr/imaging/plugin/hdOcct/meshExportC.cpp
+++ b/pxr/imaging/plugin/hdOcct/meshExportC.cpp
@@ -1,4 +1,5 @@
-// C-callable mesh export for use via ctypes/Python
+// C-callable mesh export for use via ctypes/Python and the CLI tool.
+#include "api.h"
 #include "tessellator.h"
 #include "pxr/usd/usd/stage.h"
 #include "pxr/usd/usdGeom/mesh.h"
@@ -13,6 +14,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 extern "C" {
 
+HDOCCT_API
 int UsdSolid_ExportMesh(const char* inputPath, const char* outputPath, const char* primPath) {
     auto inputStage = UsdStage::Open(inputPath);
     if (!inputStage) return -1;

--- a/pxr/imaging/plugin/hdOcct/tessellator.cpp
+++ b/pxr/imaging/plugin/hdOcct/tessellator.cpp
@@ -141,25 +141,10 @@ UsdSolidTessellationResult _ExtractMesh(
         int nbNodes = tri->NbNodes();
         int nbTris = tri->NbTriangles();
 
-        // Check if surface is closed (cylinders, cones, tori) vs open (planes)
-        // This determines whether normals/winding need flipping.
-        // All BrepArray NURBS surfaces in this model have inward-pointing
-        // natural normals (du×dv toward axis) EXCEPT planar faces (end-caps)
-        // where the normal already points outward. This is because the NURBS
-        // cylinders are parameterized with U going around the circumference
-        // and V along the axis, giving du×dv pointing inward.
-        BRepAdaptor_Surface surfCheck(face, Standard_True);
-        GeomAbs_SurfaceType surfType = surfCheck.GetType();
-        // Planes don't need flip; everything else does
-        bool isClosed = (surfType != GeomAbs_Plane);
-        // For BSpline surfaces: check if it's degenerate-planar (degree 1×1)
-        if (surfType == GeomAbs_BSplineSurface) {
-            Handle(Geom_BSplineSurface) bsurf = surfCheck.BSpline();
-            if (bsurf->UDegree() == 1 && bsurf->VDegree() == 1) {
-                // Bilinear patch = planar face
-                isClosed = false;
-            }
-        }
+        // Winding/normal flip is driven by the face's OCCT orientation,
+        // which brepBuilder derives from the authored faceuse:orientationType
+        // (the outward side of each face). REVERSED means the outward
+        // direction is against the surface's natural normal.
 
         // Vertices
         for (int i = 1; i <= nbNodes; ++i) {
@@ -170,7 +155,7 @@ UsdSolidTessellationResult _ExtractMesh(
         // Normals from parametric surface
         if (params.computeNormals && tri->HasUVNodes()) {
             BRepAdaptor_Surface surfAdaptor(face, Standard_True);
-            bool flipNormal = isClosed;  // flip for closed surfaces only
+            bool flipNormal = isReversed;
             
             for (int i = 1; i <= nbNodes; ++i) {
                 gp_Pnt2d uv = tri->UVNode(i);
@@ -207,9 +192,23 @@ UsdSolidTessellationResult _ExtractMesh(
             int n1, n2, n3;
             tri->Triangle(i).Get(n1, n2, n3);
 
-            // Winding swap: closed surfaces (cylinders) need swap to match
-            // Storm/USD's front-face convention. Open surfaces (planes) don't.
-            if (isClosed) {
+            // Winding: align each triangle with the shading normals (which
+            // already encode the authored faceuse orientation). This also
+            // corrects wire-rebuilt trimmed faces whose triangulation can
+            // come out inverted even when orientation and normals are
+            // correct. Fall back to the orientation flag when normals are
+            // unavailable.
+            bool swapWinding = isReversed;
+            if (params.computeNormals && tri->HasUVNodes()) {
+                const GfVec3d& pa = result.points[vertOffset + n1 - 1];
+                const GfVec3d& pb = result.points[vertOffset + n2 - 1];
+                const GfVec3d& pc = result.points[vertOffset + n3 - 1];
+                const GfVec3d geomN = GfCross(pb - pa, pc - pa);
+                const GfVec3f& sn = result.normals[vertOffset + n1 - 1];
+                const GfVec3d shadeN(sn[0], sn[1], sn[2]);
+                swapWinding = (GfDot(geomN, shadeN) < 0);
+            }
+            if (swapWinding) {
                 std::swap(n1, n3);
             }
 


### PR DESCRIPTION
## Windows Support for hdOcct Plugin

Fixes 6 issues that prevent the plugin from building on Windows (MSVC):

### Changes

**1. `api.h` — Export macro mismatch (bug fix)**
`pxr_plugin(hdOcct)` defines `HDOCCT_EXPORTS=1`, but `api.h` checked for `USDSOLIDTESSELLATOR_EXPORTS`. On Linux this is invisible (all symbols exported by default), but on Windows no symbols were being `__declspec(dllexport)`ed. Fixed with proper `HDOCCT_API` macros + backward-compat aliases.

**2. `Packages.cmake` — Windows OCCT discovery**
Added fallback paths for vcpkg, conda, and the official OCCT Windows installer. Also added macOS Homebrew path. Improved the fatal error message with per-platform install instructions.

**3. `hdOcct/CMakeLists.txt` — LGPL static-lib check**
The previous regex `\.(a|lib)$` incorrectly matched `.lib` import libraries on Windows, which are *required* for DLL linking. Now only checks `.a` on non-Windows. On Windows we trust that `find_package(OpenCASCADE)` / vcpkg provides shared libs (the default).

**4. `meshExportC.cpp` — Missing DLL export**
`UsdSolid_ExportMesh` lacked `HDOCCT_API`, so it wasn't exported from the DLL. The CLI tool (which links against hdOcct) couldn't find the symbol on Windows.

**5. `extras/meshExport.cpp` — Missing DLL import**
Added `__declspec(dllimport)` for Windows on the `extern "C"` declaration.

**6. `hydraGenerativePlugin.cpp` — `sscanf %zu` portability**
MSVC historically warns/errors on `%zu` in `sscanf`. Replaced with `std::stoul` which is portable C++17.

### Also fixed
- Removed hardcoded `/usr/include/python3.10` include path
- Removed hardcoded Linux-specific `libpython3.10.so` fallback

### Testing
Not tested on Windows (no Windows CI available). Changes are minimal and follow established USD plugin patterns (compare hdEmbree, hdPrman api.h files).
