### PR TITLE
hdOcct: analytic curve readers + 3D-edge trimming (analytic surfaces complete)

### DIFF
--- a/pxr/imaging/plugin/hdOcct/brepArrayAdapter.cpp
+++ b/pxr/imaging/plugin/hdOcct/brepArrayAdapter.cpp
@@ -32,6 +32,7 @@ TF_DEFINE_PRIVATE_TOKENS(
     (usdSolidTessellatorData)
     (meshCount)
     (edgeCount)
+    (tangentEdgeCount)
     (points)
     (faceVertexCounts)
     (faceVertexIndices)
@@ -193,6 +194,27 @@ _BuildTessellationDataSource(const UsdPrim &prim)
                 TfToken(TfStringPrintf("edges_%zu", i)));
             meshDataSources.push_back(edgeDs);
         }
+
+        // Tangent (smooth) edges -> a parallel tangent_edges_<i> container,
+        // emitted as a separate, independently toggleable curve child.
+        if (!result.tangentEdgePoints.empty()) {
+            VtArray<GfVec3f> tpts(result.tangentEdgePoints.size());
+            for (size_t j = 0; j < result.tangentEdgePoints.size(); ++j) {
+                const GfVec3d& p = result.tangentEdgePoints[j];
+                tpts[j] = GfVec3f((float)p[0], (float)p[1], (float)p[2]);
+            }
+            HdContainerDataSourceHandle tDs =
+                HdRetainedContainerDataSource::New(
+                    _tokens->points,
+                    HdRetainedTypedSampledDataSource<VtArray<GfVec3f>>::New(
+                        tpts),
+                    _tokens->curveVertexCounts,
+                    HdRetainedTypedSampledDataSource<VtArray<int>>::New(
+                        result.tangentEdgeCurveVertexCounts));
+            meshNames.push_back(
+                TfToken(TfStringPrintf("tangent_edges_%zu", i)));
+            meshDataSources.push_back(tDs);
+        }
     }
 
     // Add mesh count
@@ -204,6 +226,12 @@ _BuildTessellationDataSource(const UsdPrim &prim)
     // Edge-group count (parallel to mesh count; edges_<i> may be absent when
     // a Brep produced no drawable edges).
     meshNames.push_back(_tokens->edgeCount);
+    meshDataSources.push_back(
+        HdRetainedTypedSampledDataSource<int>::New(
+            (int)goodResults.size()));
+
+    // Tangent-edge-group count (parallel; tangent_edges_<i> may be absent).
+    meshNames.push_back(_tokens->tangentEdgeCount);
     meshDataSources.push_back(
         HdRetainedTypedSampledDataSource<int>::New(
             (int)goodResults.size()));

--- a/pxr/imaging/plugin/hdOcct/brepArrayAdapter.cpp
+++ b/pxr/imaging/plugin/hdOcct/brepArrayAdapter.cpp
@@ -31,9 +31,11 @@ TF_DEFINE_PRIVATE_TOKENS(
     (usdSolidTessellation)
     (usdSolidTessellatorData)
     (meshCount)
+    (edgeCount)
     (points)
     (faceVertexCounts)
     (faceVertexIndices)
+    (curveVertexCounts)
     (normals)
 );
 
@@ -169,10 +171,39 @@ _BuildTessellationDataSource(const UsdPrim &prim)
         meshNames.push_back(
             TfToken(TfStringPrintf("mesh_%zu", i)));
         meshDataSources.push_back(meshDs);
+
+        // B-rep edge polylines (for the edge/line display): pack as an
+        // edges_<i> container holding points + curveVertexCounts, consumed by
+        // the procedural as a linear HdBasisCurves child.
+        if (!result.edgePoints.empty()) {
+            VtArray<GfVec3f> edgePts(result.edgePoints.size());
+            for (size_t j = 0; j < result.edgePoints.size(); ++j) {
+                const GfVec3d& p = result.edgePoints[j];
+                edgePts[j] = GfVec3f((float)p[0], (float)p[1], (float)p[2]);
+            }
+            HdContainerDataSourceHandle edgeDs =
+                HdRetainedContainerDataSource::New(
+                    _tokens->points,
+                    HdRetainedTypedSampledDataSource<VtArray<GfVec3f>>::New(
+                        edgePts),
+                    _tokens->curveVertexCounts,
+                    HdRetainedTypedSampledDataSource<VtArray<int>>::New(
+                        result.edgeCurveVertexCounts));
+            meshNames.push_back(
+                TfToken(TfStringPrintf("edges_%zu", i)));
+            meshDataSources.push_back(edgeDs);
+        }
     }
 
     // Add mesh count
     meshNames.push_back(_tokens->meshCount);
+    meshDataSources.push_back(
+        HdRetainedTypedSampledDataSource<int>::New(
+            (int)goodResults.size()));
+
+    // Edge-group count (parallel to mesh count; edges_<i> may be absent when
+    // a Brep produced no drawable edges).
+    meshNames.push_back(_tokens->edgeCount);
     meshDataSources.push_back(
         HdRetainedTypedSampledDataSource<int>::New(
             (int)goodResults.size()));

--- a/pxr/imaging/plugin/hdOcct/brepBuilder.cpp
+++ b/pxr/imaging/plugin/hdOcct/brepBuilder.cpp
@@ -397,6 +397,23 @@ UsdSolidBrepBuilder::_ReadBrepData(const UsdPrim& prim, _BrepData* data) const
     _GetAttr("brep:surface:cylinder:axis", data->surfaceCylinderAxis);
     _GetAttr("brep:surface:cylinder:refDirection", data->surfaceCylinderRefDir);
     _GetAttr("brep:surface:cylinder:radius", data->surfaceCylinderRadius);
+    _GetAttr("brep:surface:plane:origin", data->surfacePlaneOrigin);
+    _GetAttr("brep:surface:plane:axis", data->surfacePlaneAxis);
+    _GetAttr("brep:surface:plane:refDirection", data->surfacePlaneRefDir);
+    _GetAttr("brep:surface:cone:origin", data->surfaceConeOrigin);
+    _GetAttr("brep:surface:cone:axis", data->surfaceConeAxis);
+    _GetAttr("brep:surface:cone:refDirection", data->surfaceConeRefDir);
+    _GetAttr("brep:surface:cone:radius", data->surfaceConeRadius);
+    _GetAttr("brep:surface:cone:semiAngle", data->surfaceConeSemiAngle);
+    _GetAttr("brep:surface:sphere:center", data->surfaceSphereCenter);
+    _GetAttr("brep:surface:sphere:axis", data->surfaceSphereAxis);
+    _GetAttr("brep:surface:sphere:refDirection", data->surfaceSphereRefDir);
+    _GetAttr("brep:surface:sphere:radius", data->surfaceSphereRadius);
+    _GetAttr("brep:surface:torus:origin", data->surfaceTorusOrigin);
+    _GetAttr("brep:surface:torus:axis", data->surfaceTorusAxis);
+    _GetAttr("brep:surface:torus:refDirection", data->surfaceTorusRefDir);
+    _GetAttr("brep:surface:torus:majorRadius", data->surfaceTorusMajorRadius);
+    _GetAttr("brep:surface:torus:minorRadius", data->surfaceTorusMinorRadius);
 
     return !data->regionCount.empty();
 }
@@ -475,7 +492,13 @@ UsdSolidBrepBuilder::_BuildSingleBrep(
     // Faces before faceStart (earlier Breps) still advance the offsets.
     size_t surfCPOffset = 0, surfUKnotOffset = 0, surfVKnotOffset = 0,
            surfWeightOffset = 0;   // NURBS packing offsets
-    size_t nurbFace = 0, cylFace = 0;   // per-type element counters
+    size_t nurbFace = 0, cylFace = 0, planeFace = 0, coneFace = 0,
+           sphereFace = 0, torusFace = 0;   // per-type element counters
+    auto mkAx3 = [](const GfVec3d& o, const GfVec3d& ax, const GfVec3d& rd) {
+        return gp_Ax3(gp_Pnt(o[0], o[1], o[2]),
+                      gp_Dir(ax[0], ax[1], ax[2]),
+                      gp_Dir(rd[0], rd[1], rd[2]));
+    };
 
     for (size_t faceIdx = 0;
          faceIdx < faceStart + numFaces &&
@@ -496,6 +519,42 @@ UsdSolidBrepBuilder::_BuildSingleBrep(
                     ax3, data.surfaceCylinderRadius[cylFace]);
             }
             ++cylFace;
+        } else if (stype.GetString() == "BrepSurfacePlaneAPI") {
+            if (planeFace < data.surfacePlaneOrigin.size()) {
+                surf = new Geom_Plane(mkAx3(data.surfacePlaneOrigin[planeFace],
+                    data.surfacePlaneAxis[planeFace],
+                    data.surfacePlaneRefDir[planeFace]));
+            }
+            ++planeFace;
+        } else if (stype.GetString() == "BrepSurfaceConeAPI") {
+            if (coneFace < data.surfaceConeRadius.size()) {
+                surf = new Geom_ConicalSurface(
+                    mkAx3(data.surfaceConeOrigin[coneFace],
+                          data.surfaceConeAxis[coneFace],
+                          data.surfaceConeRefDir[coneFace]),
+                    data.surfaceConeSemiAngle[coneFace],
+                    data.surfaceConeRadius[coneFace]);
+            }
+            ++coneFace;
+        } else if (stype.GetString() == "BrepSurfaceSphereAPI") {
+            if (sphereFace < data.surfaceSphereRadius.size()) {
+                surf = new Geom_SphericalSurface(
+                    mkAx3(data.surfaceSphereCenter[sphereFace],
+                          data.surfaceSphereAxis[sphereFace],
+                          data.surfaceSphereRefDir[sphereFace]),
+                    data.surfaceSphereRadius[sphereFace]);
+            }
+            ++sphereFace;
+        } else if (stype.GetString() == "BrepSurfaceTorusAPI") {
+            if (torusFace < data.surfaceTorusMajorRadius.size()) {
+                surf = new Geom_ToroidalSurface(
+                    mkAx3(data.surfaceTorusOrigin[torusFace],
+                          data.surfaceTorusAxis[torusFace],
+                          data.surfaceTorusRefDir[torusFace]),
+                    data.surfaceTorusMajorRadius[torusFace],
+                    data.surfaceTorusMinorRadius[torusFace]);
+            }
+            ++torusFace;
         } else {
             // BrepSurfaceNurbAPI (default)
             if (nurbFace < data.surfaceUVertexCount.size()) {

--- a/pxr/imaging/plugin/hdOcct/brepBuilder.cpp
+++ b/pxr/imaging/plugin/hdOcct/brepBuilder.cpp
@@ -18,6 +18,13 @@
 #include <BRepBuilderAPI_Sewing.hxx>
 #include <Geom_BSplineCurve.hxx>
 #include <Geom_BSplineSurface.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_Plane.hxx>
+#include <Geom_ConicalSurface.hxx>
+#include <Geom_SphericalSurface.hxx>
+#include <Geom_ToroidalSurface.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Dir.hxx>
 #include <Geom2d_BSplineCurve.hxx>
 #include <gp_Pnt.hxx>
 #include <ShapeFix_Shape.hxx>
@@ -385,6 +392,12 @@ UsdSolidBrepBuilder::_ReadBrepData(const UsdPrim& prim, _BrepData* data) const
     _GetAttr("brep:surface:nurb:weights",
              data->surfaceWeights);
 
+    // Analytic cylinder surfaces (BrepSurfaceCylinderAPI)
+    _GetAttr("brep:surface:cylinder:origin", data->surfaceCylinderOrigin);
+    _GetAttr("brep:surface:cylinder:axis", data->surfaceCylinderAxis);
+    _GetAttr("brep:surface:cylinder:refDirection", data->surfaceCylinderRefDir);
+    _GetAttr("brep:surface:cylinder:radius", data->surfaceCylinderRadius);
+
     return !data->regionCount.empty();
 }
 
@@ -453,53 +466,60 @@ UsdSolidBrepBuilder::_BuildSingleBrep(
     }
 
     // Build OCCT surfaces for each face
-    std::vector<Handle(Geom_BSplineSurface)> surfaces;
+    std::vector<Handle(Geom_Surface)> surfaces;
     surfaces.reserve(numFaces);
 
-    size_t surfCPOffset = 0;
-    size_t surfUKnotOffset = 0;
-    size_t surfVKnotOffset = 0;
-    size_t surfWeightOffset = 0;
+    // Surface arrays are packed per surface TYPE (NURBS faces in the nurb
+    // arrays, cylinder faces in the cylinder arrays, ...). Walk faces in order,
+    // dispatch on face:surfaceType, and advance the matching per-type offsets.
+    // Faces before faceStart (earlier Breps) still advance the offsets.
+    size_t surfCPOffset = 0, surfUKnotOffset = 0, surfVKnotOffset = 0,
+           surfWeightOffset = 0;   // NURBS packing offsets
+    size_t nurbFace = 0, cylFace = 0;   // per-type element counters
 
-    // Skip surfaces before faceStart
-    for (size_t i = 0; i < faceStart && i < data.surfaceUVertexCount.size(); ++i) {
-        int uCnt = data.surfaceUVertexCount[i];
-        int vCnt = data.surfaceVVertexCount[i];
-        surfCPOffset += uCnt * vCnt;
-        surfUKnotOffset += uCnt + data.surfaceUOrder[i];
-        surfVKnotOffset += vCnt + data.surfaceVOrder[i];
-        surfWeightOffset += uCnt * vCnt;
-    }
+    for (size_t faceIdx = 0;
+         faceIdx < faceStart + numFaces &&
+         faceIdx < data.faceSurfaceType.size(); ++faceIdx) {
+        const TfToken& stype = data.faceSurfaceType[faceIdx];
+        Handle(Geom_Surface) surf;
 
-    for (size_t fi = 0; fi < numFaces; ++fi) {
-        size_t faceIdx = faceStart + fi;
-        if (faceIdx >= data.surfaceUVertexCount.size()) break;
+        if (stype.GetString() == "BrepSurfaceCylinderAPI") {
+            if (cylFace < data.surfaceCylinderRadius.size() &&
+                cylFace < data.surfaceCylinderOrigin.size()) {
+                const GfVec3d& o  = data.surfaceCylinderOrigin[cylFace];
+                const GfVec3d& ax = data.surfaceCylinderAxis[cylFace];
+                const GfVec3d& rd = data.surfaceCylinderRefDir[cylFace];
+                gp_Ax3 ax3(gp_Pnt(o[0], o[1], o[2]),
+                           gp_Dir(ax[0], ax[1], ax[2]),
+                           gp_Dir(rd[0], rd[1], rd[2]));
+                surf = new Geom_CylindricalSurface(
+                    ax3, data.surfaceCylinderRadius[cylFace]);
+            }
+            ++cylFace;
+        } else {
+            // BrepSurfaceNurbAPI (default)
+            if (nurbFace < data.surfaceUVertexCount.size()) {
+                int uCnt = data.surfaceUVertexCount[nurbFace];
+                int vCnt = data.surfaceVVertexCount[nurbFace];
+                int uOrd = data.surfaceUOrder[nurbFace];
+                int vOrd = data.surfaceVOrder[nurbFace];
+                int numUKnots = uCnt + uOrd, numVKnots = vCnt + vOrd;
+                int numCPs = uCnt * vCnt;
+                const GfVec3d* cps = data.surfaceControlVertices.cdata() + surfCPOffset;
+                const double* uKnots = data.surfaceUKnots.cdata() + surfUKnotOffset;
+                const double* vKnots = data.surfaceVKnots.cdata() + surfVKnotOffset;
+                const double* weights = (!data.surfaceWeights.empty())
+                    ? data.surfaceWeights.cdata() + surfWeightOffset : nullptr;
+                int numW = (!data.surfaceWeights.empty()) ? numCPs : 0;
+                surf = _MakeBSplineSurface(cps, uCnt, vCnt, uOrd, vOrd,
+                    uKnots, numUKnots, vKnots, numVKnots, weights, numW);
+                surfCPOffset += numCPs; surfUKnotOffset += numUKnots;
+                surfVKnotOffset += numVKnots; surfWeightOffset += numCPs;
+            }
+            ++nurbFace;
+        }
 
-        int uCnt = data.surfaceUVertexCount[faceIdx];
-        int vCnt = data.surfaceVVertexCount[faceIdx];
-        int uOrd = data.surfaceUOrder[faceIdx];
-        int vOrd = data.surfaceVOrder[faceIdx];
-        int numUKnots = uCnt + uOrd;
-        int numVKnots = vCnt + vOrd;
-        int numCPs = uCnt * vCnt;
-
-        const GfVec3d* cps = data.surfaceControlVertices.cdata() + surfCPOffset;
-        const double* uKnots = data.surfaceUKnots.cdata() + surfUKnotOffset;
-        const double* vKnots = data.surfaceVKnots.cdata() + surfVKnotOffset;
-        const double* weights = (!data.surfaceWeights.empty())
-            ? data.surfaceWeights.cdata() + surfWeightOffset : nullptr;
-        int numW = (!data.surfaceWeights.empty()) ? numCPs : 0;
-
-        auto surface = _MakeBSplineSurface(
-            cps, uCnt, vCnt, uOrd, vOrd,
-            uKnots, numUKnots, vKnots, numVKnots,
-            weights, numW);
-        surfaces.push_back(surface);
-
-        surfCPOffset += numCPs;
-        surfUKnotOffset += numUKnots;
-        surfVKnotOffset += numVKnots;
-        surfWeightOffset += numCPs;
+        if (faceIdx >= faceStart) surfaces.push_back(surf);
     }
 
     // Build faces as untrimmed NURBS surfaces.
@@ -774,9 +794,9 @@ UsdSolidBrepBuilder::_BuildSingleBrep(
 
             int numLoops = data.faceLoopCount[faceIdx];
 
-            Handle(Geom_BSplineSurface) surface =
+            Handle(Geom_Surface) surface =
                 (fi < surfaces.size()) ? surfaces[fi]
-                                       : Handle(Geom_BSplineSurface)();
+                                       : Handle(Geom_Surface)();
 
             if (surface.IsNull()) {
                 for (int li = 0; li < numLoops; ++li) {

--- a/pxr/imaging/plugin/hdOcct/brepBuilder.cpp
+++ b/pxr/imaging/plugin/hdOcct/brepBuilder.cpp
@@ -23,8 +23,21 @@
 #include <Geom_ConicalSurface.hxx>
 #include <Geom_SphericalSurface.hxx>
 #include <Geom_ToroidalSurface.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_Circle.hxx>
+#include <Geom_Ellipse.hxx>
+#include <gp_Ax2.hxx>
 #include <gp_Ax3.hxx>
 #include <gp_Dir.hxx>
+#include <BRepLib.hxx>
+#include <GeomProjLib.hxx>
+#include <Geom2d_Curve.hxx>
+#include <BRep_Builder.hxx>
+#include <BRep_Tool.hxx>
+#include <BRepCheck_Analyzer.hxx>
+#include <Geom_ElementarySurface.hxx>
+#include <Standard_Failure.hxx>
+#include <TopLoc_Location.hxx>
 #include <Geom2d_BSplineCurve.hxx>
 #include <gp_Pnt.hxx>
 #include <ShapeFix_Shape.hxx>
@@ -415,6 +428,19 @@ UsdSolidBrepBuilder::_ReadBrepData(const UsdPrim& prim, _BrepData* data) const
     _GetAttr("brep:surface:torus:majorRadius", data->surfaceTorusMajorRadius);
     _GetAttr("brep:surface:torus:minorRadius", data->surfaceTorusMinorRadius);
 
+    // Analytic 3D curves for edges (line/circle/ellipse)
+    _GetAttr("brep:edge3dLine:curve3d:line:origin", data->edgeLineOrigin);
+    _GetAttr("brep:edge3dLine:curve3d:line:direction", data->edgeLineDirection);
+    _GetAttr("brep:edge3dCircle:curve3d:circle:center", data->edgeCircleCenter);
+    _GetAttr("brep:edge3dCircle:curve3d:circle:axis", data->edgeCircleAxis);
+    _GetAttr("brep:edge3dCircle:curve3d:circle:refDirection", data->edgeCircleRefDir);
+    _GetAttr("brep:edge3dCircle:curve3d:circle:radius", data->edgeCircleRadius);
+    _GetAttr("brep:edge3dEllipse:curve3d:ellipse:center", data->edgeEllipseCenter);
+    _GetAttr("brep:edge3dEllipse:curve3d:ellipse:axis", data->edgeEllipseAxis);
+    _GetAttr("brep:edge3dEllipse:curve3d:ellipse:refDirection", data->edgeEllipseRefDir);
+    _GetAttr("brep:edge3dEllipse:curve3d:ellipse:xRadius", data->edgeEllipseXRadius);
+    _GetAttr("brep:edge3dEllipse:curve3d:ellipse:yRadius", data->edgeEllipseYRadius);
+
     return !data->regionCount.empty();
 }
 
@@ -618,150 +644,244 @@ UsdSolidBrepBuilder::_BuildSingleBrep(
     };
 
     if (!hasTrimCurves) {
-        // Surface-only path: build faces, use 3D edge curves for trimming
+        // Surface-only path: trim each face with its 3D edge curves.
+        // Build the 3D curve for every edge, dispatching on edge:curveType
+        // (NURBS / line / circle / ellipse), each packed per curve type.
+        // Analytic surfaces project robustly here (the OCCT STEP-import
+        // pattern), unlike the BSpline case where 3D-wire trimming under-meshes.
+        auto mkAx2 = [](const GfVec3d& c, const GfVec3d& n, const GfVec3d& vx) {
+            return gp_Ax2(gp_Pnt(c[0], c[1], c[2]),
+                          gp_Dir(n[0], n[1], n[2]),
+                          gp_Dir(vx[0], vx[1], vx[2]));
+        };
+        size_t numEdgesTotal = data.edgeCurveType.size();
+        std::vector<Handle(Geom_Curve)> edge3dCurves(numEdgesTotal);
+        std::vector<bool> edgeIsAnalytic(numEdgesTotal, false);
+        {
+            size_t eCP = 0, eKnot = 0, eW = 0;   // NURBS packing offsets
+            size_t nurbE = 0, lineE = 0, circE = 0, ellE = 0;
+            for (size_t ei = 0; ei < numEdgesTotal; ++ei) {
+                const std::string ct = data.edgeCurveType[ei].GetString();
+                try {
+                if (ct == "BrepCurve3dLineAPI") {
+                    edgeIsAnalytic[ei] = true;
+                    if (lineE < data.edgeLineOrigin.size() &&
+                        lineE < data.edgeLineDirection.size()) {
+                        const GfVec3d& o = data.edgeLineOrigin[lineE];
+                        const GfVec3d& d = data.edgeLineDirection[lineE];
+                        edge3dCurves[ei] = new Geom_Line(
+                            gp_Pnt(o[0], o[1], o[2]), gp_Dir(d[0], d[1], d[2]));
+                    }
+                    ++lineE;
+                } else if (ct == "BrepCurve3dCircleAPI") {
+                    edgeIsAnalytic[ei] = true;
+                    if (circE < data.edgeCircleRadius.size()) {
+                        edge3dCurves[ei] = new Geom_Circle(
+                            mkAx2(data.edgeCircleCenter[circE],
+                                  data.edgeCircleAxis[circE],
+                                  data.edgeCircleRefDir[circE]),
+                            data.edgeCircleRadius[circE]);
+                    }
+                    ++circE;
+                } else if (ct == "BrepCurve3dEllipseAPI") {
+                    edgeIsAnalytic[ei] = true;
+                    if (ellE < data.edgeEllipseXRadius.size()) {
+                        double xr = data.edgeEllipseXRadius[ellE];
+                        double yr = data.edgeEllipseYRadius[ellE];
+                        gp_Ax2 ax = mkAx2(data.edgeEllipseCenter[ellE],
+                                          data.edgeEllipseAxis[ellE],
+                                          data.edgeEllipseRefDir[ellE]);
+                        // OCCT requires major >= minor; rotate frame if not.
+                        if (xr >= yr) {
+                            edge3dCurves[ei] = new Geom_Ellipse(ax, xr, yr);
+                        } else {
+                            ax.Rotate(ax.Axis(), 1.5707963267948966);
+                            edge3dCurves[ei] = new Geom_Ellipse(ax, yr, xr);
+                        }
+                    }
+                    ++ellE;
+                } else {
+                    // BrepCurve3dNurbAPI (default)
+                    if (nurbE < data.edgeCurveVertexCount.size()) {
+                        int ncp = data.edgeCurveVertexCount[nurbE];
+                        int ord = data.edgeCurveOrder[nurbE];
+                        int nk = ncp + ord;
+                        const GfVec3d* cps =
+                            data.edgeCurveControlVertices.cdata() + eCP;
+                        const double* kn = data.edgeCurveKnots.cdata() + eKnot;
+                        const double* w = (!data.edgeCurveWeights.empty())
+                            ? data.edgeCurveWeights.cdata() + eW : nullptr;
+                        int nw = (!data.edgeCurveWeights.empty()) ? ncp : 0;
+                        edge3dCurves[ei] = _MakeBSplineCurve(
+                            cps, ncp, ord, kn, nk, w, nw);
+                        eCP += ncp; eKnot += nk; eW += ncp;
+                    }
+                    ++nurbE;
+                }
+                } catch (const Standard_Failure&) {
+                    // Malformed edge curve: leave it null; the face build skips.
+                }
+            }
+        }
+
         for (size_t fi = 0; fi < numFaces; ++fi) {
             if (fi >= surfaces.size()) break;
             const auto& surface = surfaces[fi];
             if (surface.IsNull()) continue;
 
-            // Check if this face has multiple loops (needs trimming)
+            const bool analyticSurf =
+                surface->IsKind(STANDARD_TYPE(Geom_ElementarySurface));
+
             size_t faceIdx = faceStart + fi;
-            if (faceIdx < data.faceLoopCount.size() &&
-                data.faceLoopCount[faceIdx] > 1) {
-                // Multi-loop face: build trimmed face using 3D edge curves.
-                if (data.edgeCurveControlVertices.empty() ||
-                    data.edgeCurveVertexCount.empty()) {
-                    continue;  // No 3D edge data — can't trim
-                }
+            size_t numLoops = (faceIdx < data.faceLoopCount.size())
+                ? data.faceLoopCount[faceIdx] : 0;
 
-                // Compute loop start for this face
-                size_t loopStartIdx = 0;
-                for (size_t f = 0; f < faceIdx; ++f) {
-                    if (f < data.faceLoopCount.size())
-                        loopStartIdx += data.faceLoopCount[f];
-                }
+            // Loop + edgeuse start indices for this face.
+            size_t loopStartIdx = 0;
+            for (size_t f = 0; f < faceIdx; ++f)
+                if (f < data.faceLoopCount.size())
+                    loopStartIdx += data.faceLoopCount[f];
+            size_t euStartIdx = 0;
+            for (size_t l = 0; l < loopStartIdx; ++l)
+                if (l < data.loopEdgeuseCount.size())
+                    euStartIdx += data.loopEdgeuseCount[l];
 
-                // Compute edgeuse start for this face's loops
-                size_t euStartIdx = 0;
-                for (size_t l = 0; l < loopStartIdx; ++l) {
-                    if (l < data.loopEdgeuseCount.size())
-                        euStartIdx += data.loopEdgeuseCount[l];
-                }
+            // Build a trimmed face from the loops' 3D edge wires.
+            //
+            // Analytic (elementary) surfaces use the full path for any loop
+            // count: edges bounded by edge:range, exact pcurve projection, and a
+            // validity check. NURBS surfaces keep legacy behaviour — only
+            // multi-loop faces are wire-trimmed (without pcurve projection), and
+            // single-loop faces fall through to natural bounds — because the
+            // authored curveUv path is the correct route for trimmed NURBS.
+            const bool attemptTrim = analyticSurf || numLoops > 1;
 
-                size_t numLoops = data.faceLoopCount[faceIdx];
-                bool success = true;
+            TopoDS_Face finalFace;
+            bool haveFace = false;
+
+            if (attemptTrim) {
+              try {
+                bool built = false, ok = true;
                 TopoDS_Face trimmedFace;
-
                 size_t currentEU = euStartIdx;
-                for (size_t li = 0; li < numLoops && success; ++li) {
+                for (size_t li = 0; li < numLoops && ok; ++li) {
                     size_t globalLoop = loopStartIdx + li;
                     if (globalLoop >= data.loopEdgeuseCount.size()) {
-                        success = false; break;
+                        ok = false; break;
                     }
                     size_t numEU = data.loopEdgeuseCount[globalLoop];
-                    if (numEU == 0) { currentEU += numEU; continue; }
+                    if (numEU == 0) { ok = false; break; }
 
-                    // Build wire from edgeuses in this loop
                     BRepBuilderAPI_MakeWire wireMaker;
                     for (size_t eu = 0; eu < numEU; ++eu) {
                         size_t euIdx = currentEU + eu;
                         if (euIdx >= data.edgeuseEdgeIndex.size()) {
-                            success = false; break;
+                            ok = false; break;
                         }
                         size_t edgeIdx = data.edgeuseEdgeIndex[euIdx];
-                        if (edgeIdx >= data.edgeCurveVertexCount.size()) {
-                            success = false; break;
+                        if (edgeIdx >= edge3dCurves.size() ||
+                            edge3dCurves[edgeIdx].IsNull()) {
+                            ok = false; break;
                         }
-
-                        // Compute offset into edge curve arrays
-                        size_t ecpOffset = 0, eknotOffset = 0, ewOffset = 0;
-                        for (size_t e = 0; e < edgeIdx; ++e) {
-                            ecpOffset += data.edgeCurveVertexCount[e];
-                            eknotOffset += data.edgeCurveVertexCount[e] +
-                                           data.edgeCurveOrder[e];
-                            ewOffset += data.edgeCurveVertexCount[e];
+                        // Analytic curves are infinite/periodic — bound them by
+                        // the authored edge:range parameter interval.
+                        TopoDS_Edge edge;
+                        if (edgeIsAnalytic[edgeIdx] &&
+                            2 * edgeIdx + 1 < data.edgeRange.size()) {
+                            BRepBuilderAPI_MakeEdge em(edge3dCurves[edgeIdx],
+                                data.edgeRange[2 * edgeIdx],
+                                data.edgeRange[2 * edgeIdx + 1]);
+                            if (!em.IsDone()) { ok = false; break; }
+                            edge = em.Edge();
+                        } else {
+                            BRepBuilderAPI_MakeEdge em(edge3dCurves[edgeIdx]);
+                            if (!em.IsDone()) { ok = false; break; }
+                            edge = em.Edge();
                         }
-
-                        int numCPs = data.edgeCurveVertexCount[edgeIdx];
-                        int edgeOrder = data.edgeCurveOrder[edgeIdx];
-                        int numKnots = numCPs + edgeOrder;
-
-                        const GfVec3d* cps =
-                            data.edgeCurveControlVertices.cdata() + ecpOffset;
-                        const double* knots =
-                            data.edgeCurveKnots.cdata() + eknotOffset;
-                        const double* weights =
-                            (!data.edgeCurveWeights.empty())
-                            ? data.edgeCurveWeights.cdata() + ewOffset
-                            : nullptr;
-                        int numW = (!data.edgeCurveWeights.empty())
-                                   ? numCPs : 0;
-
-                        auto curve = _MakeBSplineCurve(
-                            cps, numCPs, edgeOrder, knots, numKnots,
-                            weights, numW);
-                        if (curve.IsNull()) { success = false; break; }
-
-                        // Check if edgeuse orientation is "opposite" → reverse
-                        bool euReversed = false;
-                        if (euIdx < data.edgeuseOrientationType.size()) {
-                            euReversed = (data.edgeuseOrientationType[euIdx]
-                                          == _tokens->opposite);
+                        // Attach an exact pcurve (3D->2D projection) so curved
+                        // analytic faces mesh. NURBS keeps legacy behaviour.
+                        if (analyticSurf) {
+                            Standard_Real f, l;
+                            Handle(Geom_Curve) c3 =
+                                BRep_Tool::Curve(edge, f, l);
+                            if (!c3.IsNull()) {
+                                Handle(Geom2d_Curve) pc =
+                                    GeomProjLib::Curve2d(c3, f, l, surface);
+                                if (!pc.IsNull()) {
+                                    BRep_Builder bb;
+                                    bb.UpdateEdge(edge, pc, surface,
+                                        TopLoc_Location(),
+                                        data.intersectTol3d);
+                                }
+                            }
                         }
-
-                        // Build edge from curve
-                        BRepBuilderAPI_MakeEdge edgeMaker(curve);
-                        if (!edgeMaker.IsDone()) { success = false; break; }
-                        TopoDS_Edge edge = edgeMaker.Edge();
-                        if (euReversed) edge.Reverse();
+                        if (euIdx < data.edgeuseOrientationType.size() &&
+                            data.edgeuseOrientationType[euIdx] ==
+                                _tokens->opposite)
+                            edge.Reverse();
                         wireMaker.Add(edge);
                     }
                     currentEU += numEU;
-
-                    if (!success || !wireMaker.IsDone()) {
-                        success = false; break;
-                    }
+                    if (!ok || !wireMaker.IsDone()) { ok = false; break; }
                     TopoDS_Wire wire = wireMaker.Wire();
 
                     if (li == 0) {
-                        // First loop = outer boundary
                         BRepBuilderAPI_MakeFace faceMaker(surface, wire,
-                                                         Standard_True);
-                        if (!faceMaker.IsDone()) { success = false; break; }
+                                                          Standard_True);
+                        if (!faceMaker.IsDone()) { ok = false; break; }
                         trimmedFace = faceMaker.Face();
+                        built = true;
                     } else {
-                        // Inner loops = holes
-                        wire.Reverse();  // Inner wires must be reversed
+                        wire.Reverse();  // inner loops = holes
                         BRepBuilderAPI_MakeFace faceMaker(trimmedFace, wire);
-                        if (!faceMaker.IsDone()) { success = false; break; }
+                        if (!faceMaker.IsDone()) { ok = false; break; }
                         trimmedFace = faceMaker.Face();
                     }
                 }
 
-                if (success && !trimmedFace.IsNull()) {
-                    // KNOWN DEFECT: faces built this way (3D-curve wires
-                    // projected onto a BSpline surface) mesh to a small
-                    // fraction of their true area (e.g. cubeWithHole's
-                    // punctured face: 12.46 of ~71.7) — the projected UV
-                    // wire is malformed. Explicit per-edge pcurve
-                    // projection (ShapeFix_Edge::FixAddPCurve) was tried
-                    // and does not help. Proper fix: implement the
-                    // schema's authored curveUv (pcurve) trimming path.
+                if (built && ok && !trimmedFace.IsNull()) {
+                    // Pole-bearing surfaces (sphere/torus) need the natural seam
+                    // + degenerate pole edges added so a cap/great-circle wire
+                    // closes.
+                    bool poleSurface =
+                        surface->IsKind(STANDARD_TYPE(Geom_SphericalSurface)) ||
+                        surface->IsKind(STANDARD_TYPE(Geom_ToroidalSurface));
                     ShapeFix_Face fix(trimmedFace);
-                    fix.FixAddNaturalBoundMode() = Standard_False;
+                    fix.FixAddNaturalBoundMode() =
+                        (analyticSurf && poleSurface) ? Standard_True
+                                                      : Standard_False;
                     fix.FixWireMode() = Standard_True;
                     fix.Perform();
                     trimmedFace = fix.Face();
-                    faces.push_back(applyFaceuseOrientation(trimmedFace, fi));
-                    faceNeedsFlip.push_back(false);
+                    BRepLib::SameParameter(trimmedFace, data.intersectTol3d);
+                    // Analytic faces are validity-checked so invalid singular
+                    // caps are skipped cleanly; NURBS keeps legacy behaviour.
+                    if (!analyticSurf ||
+                        BRepCheck_Analyzer(trimmedFace).IsValid()) {
+                        finalFace = trimmedFace;
+                        haveFace = true;
+                    }
                 }
-                continue;
+              } catch (const Standard_Failure&) {
+                  haveFace = false;   // never let an OCCT throw crash tessellation
+              }
             }
 
-            BRepBuilderAPI_MakeFace faceMaker(surface, data.intersectTol3d);
-            if (faceMaker.IsDone()) {
-                faces.push_back(
-                    applyFaceuseOrientation(faceMaker.Face(), fi));
+            // Untrimmed fallback: single-loop NURBS faces (legacy) and faces
+            // with no boundary loops fall back to natural surface bounds. Faces
+            // that had edges but failed to trim are skipped (no garbage geometry).
+            if (!haveFace && (!attemptTrim || numLoops == 0)) {
+                try {
+                    BRepBuilderAPI_MakeFace faceMaker(
+                        surface, data.intersectTol3d);
+                    if (faceMaker.IsDone()) {
+                        finalFace = faceMaker.Face();
+                        haveFace = true;
+                    }
+                } catch (const Standard_Failure&) {}
+            }
+            if (haveFace) {
+                faces.push_back(applyFaceuseOrientation(finalFace, fi));
                 faceNeedsFlip.push_back(false);
             }
         }

--- a/pxr/imaging/plugin/hdOcct/brepBuilder.h
+++ b/pxr/imaging/plugin/hdOcct/brepBuilder.h
@@ -130,6 +130,30 @@ private:
         VtArray<double> surfaceUKnots;
         VtArray<double> surfaceVKnots;
         VtArray<double> surfaceWeights;
+
+        // Analytic surfaces (BrepSurfaceCylinderAPI; more types to follow).
+        // Each array is packed in order used by faces of that surface type.
+        VtArray<GfVec3d> surfaceCylinderOrigin;
+        VtArray<GfVec3d> surfaceCylinderAxis;
+        VtArray<GfVec3d> surfaceCylinderRefDir;
+        VtArray<double>  surfaceCylinderRadius;
+        VtArray<GfVec3d> surfacePlaneOrigin;
+        VtArray<GfVec3d> surfacePlaneAxis;
+        VtArray<GfVec3d> surfacePlaneRefDir;
+        VtArray<GfVec3d> surfaceConeOrigin;
+        VtArray<GfVec3d> surfaceConeAxis;
+        VtArray<GfVec3d> surfaceConeRefDir;
+        VtArray<double>  surfaceConeRadius;
+        VtArray<double>  surfaceConeSemiAngle;
+        VtArray<GfVec3d> surfaceSphereCenter;
+        VtArray<GfVec3d> surfaceSphereAxis;
+        VtArray<GfVec3d> surfaceSphereRefDir;
+        VtArray<double>  surfaceSphereRadius;
+        VtArray<GfVec3d> surfaceTorusOrigin;
+        VtArray<GfVec3d> surfaceTorusAxis;
+        VtArray<GfVec3d> surfaceTorusRefDir;
+        VtArray<double>  surfaceTorusMajorRadius;
+        VtArray<double>  surfaceTorusMinorRadius;
     };
 
     bool _ReadBrepData(const UsdPrim& prim, _BrepData* data) const;

--- a/pxr/imaging/plugin/hdOcct/brepBuilder.h
+++ b/pxr/imaging/plugin/hdOcct/brepBuilder.h
@@ -154,6 +154,19 @@ private:
         VtArray<GfVec3d> surfaceTorusRefDir;
         VtArray<double>  surfaceTorusMajorRadius;
         VtArray<double>  surfaceTorusMinorRadius;
+
+        // Analytic 3D curves for edges (line/circle/ellipse), packed per type.
+        VtArray<GfVec3d> edgeLineOrigin;
+        VtArray<GfVec3d> edgeLineDirection;
+        VtArray<GfVec3d> edgeCircleCenter;
+        VtArray<GfVec3d> edgeCircleAxis;
+        VtArray<GfVec3d> edgeCircleRefDir;
+        VtArray<double>  edgeCircleRadius;
+        VtArray<GfVec3d> edgeEllipseCenter;
+        VtArray<GfVec3d> edgeEllipseAxis;
+        VtArray<GfVec3d> edgeEllipseRefDir;
+        VtArray<double>  edgeEllipseXRadius;
+        VtArray<double>  edgeEllipseYRadius;
     };
 
     bool _ReadBrepData(const UsdPrim& prim, _BrepData* data) const;

--- a/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.cpp
+++ b/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.cpp
@@ -313,7 +313,7 @@ UsdSolidTessellationProcedural::GetChildPrim(
                 HdRetainedTypedSampledDataSource<TfToken>::New(
                     HdPrimvarSchemaTokens->point));
         VtArray<GfVec3f> edgeColor(1, isTangent
-            ? GfVec3f(0.5f, 0.5f, 0.55f) : GfVec3f(0.05f, 0.05f, 0.05f));
+            ? GfVec3f(0.0f, 0.95f, 1.0f) : GfVec3f(0.05f, 0.05f, 0.05f));
         HdContainerDataSourceHandle colorPvDs =
             HdRetainedContainerDataSource::New(
                 HdPrimvarSchemaTokens->primvarValue,

--- a/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.cpp
+++ b/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.cpp
@@ -312,10 +312,8 @@ UsdSolidTessellationProcedural::GetChildPrim(
                 HdPrimvarSchemaTokens->role,
                 HdRetainedTypedSampledDataSource<TfToken>::New(
                     HdPrimvarSchemaTokens->point));
-        // Both edge sets are cyan, separated by ~20 deg of hue: sharp =
-        // blue-cyan (~190 deg), tangent = green-cyan (~170 deg).
-        VtArray<GfVec3f> edgeColor(1, isTangent
-            ? GfVec3f(0.0f, 1.0f, 0.83f) : GfVec3f(0.0f, 0.83f, 1.0f));
+        // Dark grey for all edges (sharp and tangent alike).
+        VtArray<GfVec3f> edgeColor(1, GfVec3f(0.15f, 0.15f, 0.15f));
         HdContainerDataSourceHandle colorPvDs =
             HdRetainedContainerDataSource::New(
                 HdPrimvarSchemaTokens->primvarValue,

--- a/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.cpp
+++ b/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.cpp
@@ -312,8 +312,10 @@ UsdSolidTessellationProcedural::GetChildPrim(
                 HdPrimvarSchemaTokens->role,
                 HdRetainedTypedSampledDataSource<TfToken>::New(
                     HdPrimvarSchemaTokens->point));
+        // Both edge sets are cyan, separated by ~20 deg of hue: sharp =
+        // blue-cyan (~190 deg), tangent = green-cyan (~170 deg).
         VtArray<GfVec3f> edgeColor(1, isTangent
-            ? GfVec3f(0.0f, 0.95f, 1.0f) : GfVec3f(0.05f, 0.05f, 0.05f));
+            ? GfVec3f(0.0f, 1.0f, 0.83f) : GfVec3f(0.0f, 0.83f, 1.0f));
         HdContainerDataSourceHandle colorPvDs =
             HdRetainedContainerDataSource::New(
                 HdPrimvarSchemaTokens->primvarValue,
@@ -325,10 +327,25 @@ UsdSolidTessellationProcedural::GetChildPrim(
                 HdPrimvarSchemaTokens->role,
                 HdRetainedTypedSampledDataSource<TfToken>::New(
                     HdPrimvarSchemaTokens->color));
+        // Explicit constant line width (world units). Without an authored
+        // widths primvar Storm draws curves at a thin 1px default; this makes
+        // the edge overlay noticeably thicker / easier to read.
+        VtArray<float> edgeWidth(1, 0.1f);
+        HdContainerDataSourceHandle widthPvDs =
+            HdRetainedContainerDataSource::New(
+                HdPrimvarSchemaTokens->primvarValue,
+                HdRetainedTypedSampledDataSource<VtArray<float>>::New(
+                    edgeWidth),
+                HdPrimvarSchemaTokens->interpolation,
+                HdRetainedTypedSampledDataSource<TfToken>::New(
+                    HdPrimvarSchemaTokens->constant),
+                HdPrimvarSchemaTokens->role,
+                HdRetainedTypedSampledDataSource<TfToken>::New(TfToken()));
         HdContainerDataSourceHandle primvarsDs =
             HdRetainedContainerDataSource::New(
                 HdTokens->points, pointsPvDs,
-                HdTokens->displayColor, colorPvDs);
+                HdTokens->displayColor, colorPvDs,
+                HdTokens->widths, widthPvDs);
 
         HdContainerDataSourceHandle xformDs;
         if (inputScene) {

--- a/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.cpp
+++ b/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.cpp
@@ -14,6 +14,9 @@
 #include "pxr/base/tf/type.h"
 #include "pxr/imaging/hd/meshSchema.h"
 #include "pxr/imaging/hd/meshTopologySchema.h"
+#include "pxr/imaging/hd/basisCurvesSchema.h"
+#include "pxr/imaging/hd/basisCurvesTopologySchema.h"
+#include "pxr/imaging/hd/purposeSchema.h"
 #include "pxr/imaging/pxOsd/tokens.h"
 #include "pxr/imaging/hd/primvarSchema.h"
 #include "pxr/imaging/hd/primvarsSchema.h"
@@ -28,9 +31,11 @@ TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
     (usdSolidTessellatorData)
     (meshCount)
+    (edgeCount)
     (points)
     (faceVertexCounts)
     (faceVertexIndices)
+    (curveVertexCounts)
     (normals)
     (displayColor)
 );
@@ -63,6 +68,7 @@ UsdSolidTessellationProcedural::_Tessellate(
     const HdSceneIndexBaseRefPtr &inputScene)
 {
     _meshes.clear();
+    _edges.clear();
 
     const SdfPath primPath = _GetProceduralPrimPath();
     HdSceneIndexPrim prim = inputScene->GetPrim(primPath);
@@ -144,6 +150,33 @@ UsdSolidTessellationProcedural::_Tessellate(
             _meshes.push_back(std::move(mesh));
         }
     }
+
+    // Unpack B-rep edge polylines (edges_<i> containers) into linear-curve data.
+    int edgeCount = 0;
+    if (auto ecDs = HdTypedSampledDataSource<int>::Cast(
+            tessDs->Get(_tokens->edgeCount))) {
+        edgeCount = ecDs->GetTypedValue(0.0f);
+    }
+    for (int i = 0; i < edgeCount; ++i) {
+        TfToken edgeName(TfStringPrintf("edges_%d", i));
+        HdContainerDataSourceHandle edgeDs =
+            HdContainerDataSource::Cast(tessDs->Get(edgeName));
+        if (!edgeDs) {
+            continue;  // this Brep produced no drawable edges
+        }
+        _EdgeData edge;
+        if (auto pDs = HdTypedSampledDataSource<VtArray<GfVec3f>>::Cast(
+                edgeDs->Get(_tokens->points))) {
+            edge.points = pDs->GetTypedValue(0.0f);
+        }
+        if (auto cvcDs = HdTypedSampledDataSource<VtArray<int>>::Cast(
+                edgeDs->Get(_tokens->curveVertexCounts))) {
+            edge.curveVertexCounts = cvcDs->GetTypedValue(0.0f);
+        }
+        if (!edge.points.empty() && !edge.curveVertexCounts.empty()) {
+            _edges.push_back(std::move(edge));
+        }
+    }
 }
 
 HdGpGenerativeProcedural::ChildPrimTypeMap
@@ -166,6 +199,11 @@ UsdSolidTessellationProcedural::Update(
             TfToken(TfStringPrintf("tessellated_mesh_%zu", i)));
         result[childPath] = HdPrimTypeTokens->mesh;
     }
+    for (size_t i = 0; i < _edges.size(); ++i) {
+        SdfPath childPath = _GetProceduralPrimPath().AppendChild(
+            TfToken(TfStringPrintf("tessellated_edges_%zu", i)));
+        result[childPath] = HdPrimTypeTokens->basisCurves;
+    }
 
     // If previous results existed, dirty all children
     if (!previousResult.empty() && outputDirtiedPrims) {
@@ -185,11 +223,104 @@ UsdSolidTessellationProcedural::GetChildPrim(
 {
     std::lock_guard<std::mutex> lock(_mutex);
 
+    const std::string childName = childPrimPath.GetName();
+
+    // B-rep edge polylines -> a linear HdBasisCurves child, marked purpose=guide
+    // so usdview's "Display > Guides" toggles the edge overlay like a wireframe.
+    const std::string edgePrefix = "tessellated_edges_";
+    if (childName.compare(0, edgePrefix.size(), edgePrefix) == 0) {
+        HdSceneIndexPrim cresult;
+        cresult.primType = HdPrimTypeTokens->basisCurves;
+        size_t edgeIdx = 0;
+        try {
+            edgeIdx = std::stoul(childName.substr(edgePrefix.size()));
+        } catch (...) {
+            return cresult;
+        }
+        if (edgeIdx >= _edges.size()) {
+            return cresult;
+        }
+        const _EdgeData &edge = _edges[edgeIdx];
+
+        HdContainerDataSourceHandle curveTopo =
+            HdBasisCurvesTopologySchema::Builder()
+                .SetCurveVertexCounts(
+                    HdRetainedTypedSampledDataSource<VtArray<int>>::New(
+                        edge.curveVertexCounts))
+                .SetType(HdRetainedTypedSampledDataSource<TfToken>::New(
+                    HdTokens->linear))
+                .SetWrap(HdRetainedTypedSampledDataSource<TfToken>::New(
+                    HdTokens->nonperiodic))
+                .Build();
+        HdContainerDataSourceHandle curvesDs =
+            HdBasisCurvesSchema::Builder()
+                .SetTopology(curveTopo)
+                .Build();
+
+        HdContainerDataSourceHandle pointsPvDs =
+            HdRetainedContainerDataSource::New(
+                HdPrimvarSchemaTokens->primvarValue,
+                HdRetainedTypedSampledDataSource<VtArray<GfVec3f>>::New(
+                    edge.points),
+                HdPrimvarSchemaTokens->interpolation,
+                HdRetainedTypedSampledDataSource<TfToken>::New(
+                    HdPrimvarSchemaTokens->vertex),
+                HdPrimvarSchemaTokens->role,
+                HdRetainedTypedSampledDataSource<TfToken>::New(
+                    HdPrimvarSchemaTokens->point));
+        VtArray<GfVec3f> edgeColor(1, GfVec3f(0.05f, 0.05f, 0.05f));
+        HdContainerDataSourceHandle colorPvDs =
+            HdRetainedContainerDataSource::New(
+                HdPrimvarSchemaTokens->primvarValue,
+                HdRetainedTypedSampledDataSource<VtArray<GfVec3f>>::New(
+                    edgeColor),
+                HdPrimvarSchemaTokens->interpolation,
+                HdRetainedTypedSampledDataSource<TfToken>::New(
+                    HdPrimvarSchemaTokens->constant),
+                HdPrimvarSchemaTokens->role,
+                HdRetainedTypedSampledDataSource<TfToken>::New(
+                    HdPrimvarSchemaTokens->color));
+        HdContainerDataSourceHandle primvarsDs =
+            HdRetainedContainerDataSource::New(
+                HdTokens->points, pointsPvDs,
+                HdTokens->displayColor, colorPvDs);
+
+        HdContainerDataSourceHandle xformDs;
+        if (inputScene) {
+            const HdSceneIndexPrim procPrim =
+                inputScene->GetPrim(_GetProceduralPrimPath());
+            if (procPrim.dataSource) {
+                if (HdXformSchema xs =
+                        HdXformSchema::GetFromParent(procPrim.dataSource)) {
+                    xformDs = xs.GetContainer();
+                }
+            }
+        }
+        HdContainerDataSourceHandle purposeDs =
+            HdPurposeSchema::Builder()
+                .SetPurpose(HdRetainedTypedSampledDataSource<TfToken>::New(
+                    HdRenderTagTokens->guide))
+                .Build();
+
+        if (xformDs) {
+            cresult.dataSource = HdRetainedContainerDataSource::New(
+                HdBasisCurvesSchemaTokens->basisCurves, curvesDs,
+                HdPrimvarsSchemaTokens->primvars, primvarsDs,
+                HdXformSchemaTokens->xform, xformDs,
+                HdPurposeSchemaTokens->purpose, purposeDs);
+        } else {
+            cresult.dataSource = HdRetainedContainerDataSource::New(
+                HdBasisCurvesSchemaTokens->basisCurves, curvesDs,
+                HdPrimvarsSchemaTokens->primvars, primvarsDs,
+                HdPurposeSchemaTokens->purpose, purposeDs);
+        }
+        return cresult;
+    }
+
     HdSceneIndexPrim result;
     result.primType = HdPrimTypeTokens->mesh;
 
     // Parse mesh index from child name
-    const std::string childName = childPrimPath.GetName();
     const std::string prefix = "tessellated_mesh_";
     size_t meshIdx = 0;
     if (childName.substr(0, prefix.size()) != prefix) {

--- a/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.cpp
+++ b/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.cpp
@@ -32,6 +32,7 @@ TF_DEFINE_PRIVATE_TOKENS(
     (usdSolidTessellatorData)
     (meshCount)
     (edgeCount)
+    (tangentEdgeCount)
     (points)
     (faceVertexCounts)
     (faceVertexIndices)
@@ -69,6 +70,7 @@ UsdSolidTessellationProcedural::_Tessellate(
 {
     _meshes.clear();
     _edges.clear();
+    _tangentEdges.clear();
 
     const SdfPath primPath = _GetProceduralPrimPath();
     HdSceneIndexPrim prim = inputScene->GetPrim(primPath);
@@ -177,6 +179,33 @@ UsdSolidTessellationProcedural::_Tessellate(
             _edges.push_back(std::move(edge));
         }
     }
+
+    // Unpack tangent (smooth) edge polylines (tangent_edges_<i> containers).
+    int tangentEdgeCount = 0;
+    if (auto tcDs = HdTypedSampledDataSource<int>::Cast(
+            tessDs->Get(_tokens->tangentEdgeCount))) {
+        tangentEdgeCount = tcDs->GetTypedValue(0.0f);
+    }
+    for (int i = 0; i < tangentEdgeCount; ++i) {
+        TfToken name(TfStringPrintf("tangent_edges_%d", i));
+        HdContainerDataSourceHandle tDs =
+            HdContainerDataSource::Cast(tessDs->Get(name));
+        if (!tDs) {
+            continue;
+        }
+        _EdgeData edge;
+        if (auto pDs = HdTypedSampledDataSource<VtArray<GfVec3f>>::Cast(
+                tDs->Get(_tokens->points))) {
+            edge.points = pDs->GetTypedValue(0.0f);
+        }
+        if (auto cvcDs = HdTypedSampledDataSource<VtArray<int>>::Cast(
+                tDs->Get(_tokens->curveVertexCounts))) {
+            edge.curveVertexCounts = cvcDs->GetTypedValue(0.0f);
+        }
+        if (!edge.points.empty() && !edge.curveVertexCounts.empty()) {
+            _tangentEdges.push_back(std::move(edge));
+        }
+    }
 }
 
 HdGpGenerativeProcedural::ChildPrimTypeMap
@@ -204,6 +233,11 @@ UsdSolidTessellationProcedural::Update(
             TfToken(TfStringPrintf("tessellated_edges_%zu", i)));
         result[childPath] = HdPrimTypeTokens->basisCurves;
     }
+    for (size_t i = 0; i < _tangentEdges.size(); ++i) {
+        SdfPath childPath = _GetProceduralPrimPath().AppendChild(
+            TfToken(TfStringPrintf("tessellated_tangent_edges_%zu", i)));
+        result[childPath] = HdPrimTypeTokens->basisCurves;
+    }
 
     // If previous results existed, dirty all children
     if (!previousResult.empty() && outputDirtiedPrims) {
@@ -227,20 +261,30 @@ UsdSolidTessellationProcedural::GetChildPrim(
 
     // B-rep edge polylines -> a linear HdBasisCurves child, marked purpose=guide
     // so usdview's "Display > Guides" toggles the edge overlay like a wireframe.
+    // Sharp/feature edges (dark) and tangent/smooth edges (lighter) are emitted
+    // as separate child sets so tangent edges can be toggled independently.
+    const std::string tanPrefix = "tessellated_tangent_edges_";
     const std::string edgePrefix = "tessellated_edges_";
-    if (childName.compare(0, edgePrefix.size(), edgePrefix) == 0) {
+    const bool isTangent =
+        childName.compare(0, tanPrefix.size(), tanPrefix) == 0;
+    const bool isSharp = !isTangent &&
+        childName.compare(0, edgePrefix.size(), edgePrefix) == 0;
+    if (isSharp || isTangent) {
         HdSceneIndexPrim cresult;
         cresult.primType = HdPrimTypeTokens->basisCurves;
+        const std::vector<_EdgeData> &edgeSet =
+            isTangent ? _tangentEdges : _edges;
+        const std::string &pfx = isTangent ? tanPrefix : edgePrefix;
         size_t edgeIdx = 0;
         try {
-            edgeIdx = std::stoul(childName.substr(edgePrefix.size()));
+            edgeIdx = std::stoul(childName.substr(pfx.size()));
         } catch (...) {
             return cresult;
         }
-        if (edgeIdx >= _edges.size()) {
+        if (edgeIdx >= edgeSet.size()) {
             return cresult;
         }
-        const _EdgeData &edge = _edges[edgeIdx];
+        const _EdgeData &edge = edgeSet[edgeIdx];
 
         HdContainerDataSourceHandle curveTopo =
             HdBasisCurvesTopologySchema::Builder()
@@ -268,7 +312,8 @@ UsdSolidTessellationProcedural::GetChildPrim(
                 HdPrimvarSchemaTokens->role,
                 HdRetainedTypedSampledDataSource<TfToken>::New(
                     HdPrimvarSchemaTokens->point));
-        VtArray<GfVec3f> edgeColor(1, GfVec3f(0.05f, 0.05f, 0.05f));
+        VtArray<GfVec3f> edgeColor(1, isTangent
+            ? GfVec3f(0.5f, 0.5f, 0.55f) : GfVec3f(0.05f, 0.05f, 0.05f));
         HdContainerDataSourceHandle colorPvDs =
             HdRetainedContainerDataSource::New(
                 HdPrimvarSchemaTokens->primvarValue,

--- a/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.h
+++ b/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.h
@@ -81,7 +81,8 @@ private:
     };
 
     std::vector<_MeshData> _meshes;
-    std::vector<_EdgeData> _edges;
+    std::vector<_EdgeData> _edges;          // sharp / feature edges
+    std::vector<_EdgeData> _tangentEdges;   // smooth (fillet<->face) edges
     bool _cooked = false;
     std::mutex _mutex;  // OCCT is not thread-safe
 

--- a/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.h
+++ b/pxr/imaging/plugin/hdOcct/hydraGenerativePlugin.h
@@ -73,7 +73,15 @@ private:
         VtArray<GfVec3f> normals;
     };
 
+    // B-rep edge polylines emitted as a linear HdBasisCurves child prim,
+    // toggled via purpose=guide so it behaves like a wireframe overlay.
+    struct _EdgeData {
+        VtArray<GfVec3f> points;
+        VtArray<int> curveVertexCounts;
+    };
+
     std::vector<_MeshData> _meshes;
+    std::vector<_EdgeData> _edges;
     bool _cooked = false;
     std::mutex _mutex;  // OCCT is not thread-safe
 

--- a/pxr/imaging/plugin/hdOcct/tessellator.cpp
+++ b/pxr/imaging/plugin/hdOcct/tessellator.cpp
@@ -16,10 +16,18 @@
 #include <BRepMesh_IncrementalMesh.hxx>
 #include <BRep_Tool.hxx>
 #include <Poly_Triangulation.hxx>
+#include <Poly_Polygon3D.hxx>
+#include <TopExp.hxx>
 #include <TopExp_Explorer.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
 #include <TopoDS.hxx>
 #include <TopoDS_Face.hxx>
+#include <TopoDS_Edge.hxx>
 #include <TopLoc_Location.hxx>
+#include <TColgp_Array1OfPnt.hxx>
+#include <BRepAdaptor_Curve.hxx>
+#include <GCPnts_QuasiUniformDeflection.hxx>
+#include <Standard_Failure.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>
 #include <BRepGProp.hxx>
@@ -229,6 +237,55 @@ UsdSolidTessellationResult _ExtractMesh(
         faceIndex++;
     }
 
+    // Discretize the B-rep's topological edges into polylines for the optional
+    // edge/line display. Each unique edge becomes one polyline; we prefer the
+    // 3D polygon BRepMesh already attached to the edge (coincident with the
+    // meshed faces), and fall back to sampling the 3D curve directly.
+    {
+        TopTools_IndexedMapOfShape edgeMap;
+        TopExp::MapShapes(shape, TopAbs_EDGE, edgeMap);
+        for (int ei = 1; ei <= edgeMap.Extent(); ++ei) {
+            const TopoDS_Edge& edge = TopoDS::Edge(edgeMap(ei));
+            if (BRep_Tool::Degenerated(edge)) {
+                continue;  // seam/degenerate edges carry no 3D curve
+            }
+            std::vector<GfVec3d> pts;
+
+            TopLoc_Location eloc;
+            Handle(Poly_Polygon3D) poly = BRep_Tool::Polygon3D(edge, eloc);
+            if (!poly.IsNull()) {
+                const gp_Trsf& et = eloc.Transformation();
+                const TColgp_Array1OfPnt& nodes = poly->Nodes();
+                pts.reserve(nodes.Length());
+                for (int i = nodes.Lower(); i <= nodes.Upper(); ++i) {
+                    gp_Pnt p = nodes.Value(i).Transformed(et);
+                    pts.emplace_back(p.X(), p.Y(), p.Z());
+                }
+            } else {
+                try {
+                    BRepAdaptor_Curve curve(edge);
+                    GCPnts_QuasiUniformDeflection disc(curve, deflection);
+                    if (disc.IsDone()) {
+                        pts.reserve(disc.NbPoints());
+                        for (int i = 1; i <= disc.NbPoints(); ++i) {
+                            gp_Pnt p = disc.Value(i);
+                            pts.emplace_back(p.X(), p.Y(), p.Z());
+                        }
+                    }
+                } catch (const Standard_Failure&) {
+                    continue;  // skip edges that cannot be discretized
+                }
+            }
+
+            if (pts.size() >= 2) {
+                result.edgeCurveVertexCounts.push_back((int)pts.size());
+                for (const auto& p : pts) {
+                    result.edgePoints.push_back(p);
+                }
+            }
+        }
+    }
+
     result.success = true;
     return result;
 }
@@ -283,6 +340,13 @@ UsdSolidTessellationResult _MergeResults(
             merged.faceBrepIndices.push_back(bi);
         for (const auto& fi : r.faceSolidFaceIndices)
             merged.faceSolidFaceIndices.push_back(fi);
+
+        // Edge polylines are a flat point array partitioned by per-curve
+        // counts; no index remap needed, just concatenate both arrays.
+        for (const auto& c : r.edgeCurveVertexCounts)
+            merged.edgeCurveVertexCounts.push_back(c);
+        for (const auto& p : r.edgePoints)
+            merged.edgePoints.push_back(p);
 
         vertOffset += (int)r.points.size();
     }

--- a/pxr/imaging/plugin/hdOcct/tessellator.cpp
+++ b/pxr/imaging/plugin/hdOcct/tessellator.cpp
@@ -17,6 +17,8 @@
 #include <BRep_Tool.hxx>
 #include <Poly_Triangulation.hxx>
 #include <Poly_Polygon3D.hxx>
+#include <Poly_PolygonOnTriangulation.hxx>
+#include <TColStd_Array1OfInteger.hxx>
 #include <TopExp.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>
@@ -320,38 +322,46 @@ UsdSolidTessellationResult _ExtractMesh(
                                     const TopoDS_Face& face,
                                     double offset,
                                     std::vector<GfVec3d>& pts) {
-            Standard_Real f2, l2;
-            Handle(Geom2d_Curve) pc =
-                BRep_Tool::CurveOnSurface(edge, face, f2, l2);
-            TopLoc_Location loc;
-            Handle(Geom_Surface) surf = BRep_Tool::Surface(face, loc);
-            if (pc.IsNull() || surf.IsNull()) { discretize(edge, pts); return; }
+            // Take the edge's vertices straight from the face's surface
+            // triangulation (PolygonOnTriangulation), so the edge polyline is
+            // sampled at exactly the same nodes the fillet surface mesh uses;
+            // then push each node a hair along its outward surface normal so the
+            // line sits just proud of the facets instead of z-fighting them.
             try {
-                BRepAdaptor_Curve curve(edge);
-                GCPnts_QuasiUniformDeflection disc(curve, deflection);
-                if (!disc.IsDone() || disc.NbPoints() < 2) {
+                TopLoc_Location triLoc;
+                Handle(Poly_Triangulation) tri =
+                    BRep_Tool::Triangulation(face, triLoc);
+                if (tri.IsNull() || !tri->HasUVNodes()) {
                     discretize(edge, pts);
                     return;
                 }
-                const gp_Trsf& lt = loc.Transformation();
+                Handle(Poly_PolygonOnTriangulation) poly =
+                    BRep_Tool::PolygonOnTriangulation(edge, tri, triLoc);
+                if (poly.IsNull()) { discretize(edge, pts); return; }
+                // World-space surface (location applied) -> D1 gives world
+                // derivatives, so the normal needs no further transform; the
+                // triangulation nodes are local and do need triLoc applied.
+                Handle(Geom_Surface) surf = BRep_Tool::Surface(face);
+                const gp_Trsf& tt = triLoc.Transformation();
                 const bool rev = (face.Orientation() == TopAbs_REVERSED);
-                pts.reserve(disc.NbPoints());
-                for (int i = 1; i <= disc.NbPoints(); ++i) {
-                    Standard_Real t = disc.Parameter(i);
-                    gp_Pnt p3 = disc.Value(i);
-                    gp_Pnt2d uv = pc->Value(t);
-                    gp_Pnt sp; gp_Vec du, dv;
-                    surf->D1(uv.X(), uv.Y(), sp, du, dv);
-                    gp_Vec n = du.Crossed(dv);
-                    if (n.Magnitude() < 1e-12) {
-                        pts.emplace_back(p3.X(), p3.Y(), p3.Z());
-                        continue;
+                const TColStd_Array1OfInteger& nodes = poly->Nodes();
+                pts.reserve(nodes.Length());
+                for (int i = nodes.Lower(); i <= nodes.Upper(); ++i) {
+                    const int n = nodes.Value(i);
+                    gp_Pnt p = tri->Node(n).Transformed(tt);
+                    gp_Vec nrm(0, 0, 0);
+                    if (!surf.IsNull()) {
+                        gp_Pnt2d uv = tri->UVNode(n);
+                        gp_Pnt sp; gp_Vec du, dv;
+                        surf->D1(uv.X(), uv.Y(), sp, du, dv);
+                        nrm = du.Crossed(dv);
                     }
-                    n.Normalize();
-                    if (rev) n.Reverse();
-                    if (!loc.IsIdentity()) n.Transform(lt);
-                    gp_Pnt po = p3.Translated(n.Multiplied(offset));
-                    pts.emplace_back(po.X(), po.Y(), po.Z());
+                    if (nrm.Magnitude() > 1e-12) {
+                        nrm.Normalize();
+                        if (rev) nrm.Reverse();
+                        p.Translate(nrm.Multiplied(offset));
+                    }
+                    pts.emplace_back(p.X(), p.Y(), p.Z());
                 }
             } catch (const Standard_Failure&) {
                 pts.clear();
@@ -419,9 +429,10 @@ UsdSolidTessellationResult _ExtractMesh(
 
         // Tangent if the two owning faces meet at a near-zero dihedral.
         const double tangentTol = 0.15;  // radians (~8.6 deg)
-        // Lift the emitted edges this far along the outward normal. Scaled to
-        // the tessellation deflection so it always clears the facet chord error.
-        const double edgeOffset = 1.5 * deflection;
+        // Lift the emitted edges this far along the outward normal. The edge
+        // nodes are now coincident with the mesh facets, so only a small nudge
+        // (a fraction of the deflection) is needed to win the depth test.
+        const double edgeOffset = 0.3 * deflection;
         for (const auto& kv : groups) {
             const std::vector<size_t>& ids = kv.second;
             const EdgeRec& a = recs[ids[0]];

--- a/pxr/imaging/plugin/hdOcct/tessellator.cpp
+++ b/pxr/imaging/plugin/hdOcct/tessellator.cpp
@@ -310,15 +310,67 @@ UsdSolidTessellationResult _ExtractMesh(
             return gp_Dir(n);
         };
 
+        // Discretize \p edge but push each vertex \p offset along the outward
+        // surface normal of \p face, so the emitted polyline floats just proud
+        // of the tessellated surface instead of z-fighting with / hiding behind
+        // it. Per-vertex (not constant) so curved edges (e.g. a hole rim) lift
+        // radially rather than translating. Falls back to the plain 3D
+        // discretization if the face has no pcurve / surface.
+        auto discretizeOffset = [&](const TopoDS_Edge& edge,
+                                    const TopoDS_Face& face,
+                                    double offset,
+                                    std::vector<GfVec3d>& pts) {
+            Standard_Real f2, l2;
+            Handle(Geom2d_Curve) pc =
+                BRep_Tool::CurveOnSurface(edge, face, f2, l2);
+            TopLoc_Location loc;
+            Handle(Geom_Surface) surf = BRep_Tool::Surface(face, loc);
+            if (pc.IsNull() || surf.IsNull()) { discretize(edge, pts); return; }
+            try {
+                BRepAdaptor_Curve curve(edge);
+                GCPnts_QuasiUniformDeflection disc(curve, deflection);
+                if (!disc.IsDone() || disc.NbPoints() < 2) {
+                    discretize(edge, pts);
+                    return;
+                }
+                const gp_Trsf& lt = loc.Transformation();
+                const bool rev = (face.Orientation() == TopAbs_REVERSED);
+                pts.reserve(disc.NbPoints());
+                for (int i = 1; i <= disc.NbPoints(); ++i) {
+                    Standard_Real t = disc.Parameter(i);
+                    gp_Pnt p3 = disc.Value(i);
+                    gp_Pnt2d uv = pc->Value(t);
+                    gp_Pnt sp; gp_Vec du, dv;
+                    surf->D1(uv.X(), uv.Y(), sp, du, dv);
+                    gp_Vec n = du.Crossed(dv);
+                    if (n.Magnitude() < 1e-12) {
+                        pts.emplace_back(p3.X(), p3.Y(), p3.Z());
+                        continue;
+                    }
+                    n.Normalize();
+                    if (rev) n.Reverse();
+                    if (!loc.IsIdentity()) n.Transform(lt);
+                    gp_Pnt po = p3.Translated(n.Multiplied(offset));
+                    pts.emplace_back(po.X(), po.Y(), po.Z());
+                }
+            } catch (const Standard_Failure&) {
+                pts.clear();
+                discretize(edge, pts);
+            }
+        };
+
         // edge -> its owning face (1:1 in the fan topology).
         TopTools_IndexedDataMapOfShapeListOfShape edgeFaceMap;
         TopExp::MapShapesAndAncestors(
             shape, TopAbs_EDGE, TopAbs_FACE, edgeFaceMap);
 
         struct EdgeRec {
-            std::vector<GfVec3d> pts;
+            std::vector<GfVec3d> pts;   // un-offset, used for coincidence keying
             gp_Dir normal;
             bool hasNormal = false;
+            TopoDS_Edge edge;
+            TopoDS_Face face;
+            bool hasFace = false;
         };
         std::vector<EdgeRec> recs;
         std::map<std::string, std::vector<size_t>> groups;  // geom-key -> recs
@@ -350,11 +402,14 @@ UsdSolidTessellationResult _ExtractMesh(
             EdgeRec rec;
             discretize(edge, rec.pts);
             if (rec.pts.size() < 2) continue;
+            rec.edge = edge;
             if (edgeFaceMap.Contains(edge)) {
                 const TopTools_ListOfShape& faces = edgeFaceMap.FindFromKey(edge);
                 if (!faces.IsEmpty()) {
+                    rec.face = TopoDS::Face(faces.First());
+                    rec.hasFace = true;
                     rec.normal = faceNormalAtEdgeMid(
-                        edge, TopoDS::Face(faces.First()), rec.hasNormal);
+                        edge, rec.face, rec.hasNormal);
                 }
             }
             size_t idx = recs.size();
@@ -364,6 +419,9 @@ UsdSolidTessellationResult _ExtractMesh(
 
         // Tangent if the two owning faces meet at a near-zero dihedral.
         const double tangentTol = 0.15;  // radians (~8.6 deg)
+        // Lift the emitted edges this far along the outward normal. Scaled to
+        // the tessellation deflection so it always clears the facet chord error.
+        const double edgeOffset = 1.5 * deflection;
         for (const auto& kv : groups) {
             const std::vector<size_t>& ids = kv.second;
             const EdgeRec& a = recs[ids[0]];
@@ -379,8 +437,13 @@ UsdSolidTessellationResult _ExtractMesh(
                 : result.edgeCurveVertexCounts;
             VtArray<GfVec3d>& points = tangent
                 ? result.tangentEdgePoints : result.edgePoints;
-            counts.push_back((int)a.pts.size());
-            for (const auto& p : a.pts) points.push_back(p);
+            std::vector<GfVec3d> outPts;
+            if (a.hasFace) {
+                discretizeOffset(a.edge, a.face, edgeOffset, outPts);
+            }
+            if (outPts.size() < 2) outPts = a.pts;  // fall back to un-offset
+            counts.push_back((int)outPts.size());
+            for (const auto& p : outPts) points.push_back(p);
         }
     }
 

--- a/pxr/imaging/plugin/hdOcct/tessellator.cpp
+++ b/pxr/imaging/plugin/hdOcct/tessellator.cpp
@@ -28,6 +28,16 @@
 #include <BRepAdaptor_Curve.hxx>
 #include <GCPnts_QuasiUniformDeflection.hxx>
 #include <Standard_Failure.hxx>
+#include <TopTools_IndexedDataMapOfShapeListOfShape.hxx>
+#include <TopTools_ListOfShape.hxx>
+#include <Geom_Surface.hxx>
+#include <Geom2d_Curve.hxx>
+#include <gp_Vec.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt2d.hxx>
+#include <map>
+#include <string>
+#include <tuple>
 #include <gp_Pnt.hxx>
 #include <gp_Dir.hxx>
 #include <BRepGProp.hxx>
@@ -238,19 +248,19 @@ UsdSolidTessellationResult _ExtractMesh(
     }
 
     // Discretize the B-rep's topological edges into polylines for the optional
-    // edge/line display. Each unique edge becomes one polyline; we prefer the
-    // 3D polygon BRepMesh already attached to the edge (coincident with the
-    // meshed faces), and fall back to sampling the 3D curve directly.
+    // edge/line display, and classify each as SHARP (feature) or TANGENT
+    // (smooth, e.g. fillet<->face). The reconstructed shape uses a "fan"
+    // topology (edges are not shared between faces), so we recover adjacency
+    // geometrically: edges that coincide in 3D are the two sides of one
+    // physical edge, and the angle between their owning faces' outward normals
+    // tells sharp (angled) from tangent (parallel). De-dups the coincident
+    // pair to one polyline. (Educated-guess classification — a producer-authored
+    // edge-continuity flag would be the schema-level source of truth.)
     {
-        TopTools_IndexedMapOfShape edgeMap;
-        TopExp::MapShapes(shape, TopAbs_EDGE, edgeMap);
-        for (int ei = 1; ei <= edgeMap.Extent(); ++ei) {
-            const TopoDS_Edge& edge = TopoDS::Edge(edgeMap(ei));
-            if (BRep_Tool::Degenerated(edge)) {
-                continue;  // seam/degenerate edges carry no 3D curve
-            }
-            std::vector<GfVec3d> pts;
-
+        // Discretize one edge into a polyline (Poly_Polygon3D if present, which
+        // is coincident with the meshed faces; else sample the 3D curve).
+        auto discretize = [&](const TopoDS_Edge& edge,
+                              std::vector<GfVec3d>& pts) {
             TopLoc_Location eloc;
             Handle(Poly_Polygon3D) poly = BRep_Tool::Polygon3D(edge, eloc);
             if (!poly.IsNull()) {
@@ -273,16 +283,104 @@ UsdSolidTessellationResult _ExtractMesh(
                         }
                     }
                 } catch (const Standard_Failure&) {
-                    continue;  // skip edges that cannot be discretized
                 }
             }
+        };
 
-            if (pts.size() >= 2) {
-                result.edgeCurveVertexCounts.push_back((int)pts.size());
-                for (const auto& p : pts) {
-                    result.edgePoints.push_back(p);
+        // Outward surface normal of \p face at the midpoint of \p edge's pcurve.
+        auto faceNormalAtEdgeMid = [&](const TopoDS_Edge& edge,
+                                       const TopoDS_Face& face,
+                                       bool& ok) -> gp_Dir {
+            ok = false;
+            Standard_Real f2, l2;
+            Handle(Geom2d_Curve) pc =
+                BRep_Tool::CurveOnSurface(edge, face, f2, l2);
+            TopLoc_Location loc;
+            Handle(Geom_Surface) surf = BRep_Tool::Surface(face, loc);
+            if (pc.IsNull() || surf.IsNull()) return gp_Dir(0, 0, 1);
+            gp_Pnt2d uv = pc->Value(0.5 * (f2 + l2));
+            gp_Pnt p; gp_Vec du, dv;
+            surf->D1(uv.X(), uv.Y(), p, du, dv);
+            gp_Vec n = du.Crossed(dv);
+            if (n.Magnitude() < 1e-12) return gp_Dir(0, 0, 1);
+            n.Normalize();
+            if (face.Orientation() == TopAbs_REVERSED) n.Reverse();
+            if (!loc.IsIdentity()) n.Transform(loc.Transformation());
+            ok = true;
+            return gp_Dir(n);
+        };
+
+        // edge -> its owning face (1:1 in the fan topology).
+        TopTools_IndexedDataMapOfShapeListOfShape edgeFaceMap;
+        TopExp::MapShapesAndAncestors(
+            shape, TopAbs_EDGE, TopAbs_FACE, edgeFaceMap);
+
+        struct EdgeRec {
+            std::vector<GfVec3d> pts;
+            gp_Dir normal;
+            bool hasNormal = false;
+        };
+        std::vector<EdgeRec> recs;
+        std::map<std::string, std::vector<size_t>> groups;  // geom-key -> recs
+
+        auto keyOf = [](const std::vector<GfVec3d>& pts) {
+            auto q = [](double v) {
+                return (long long)std::llround(v * 1000.0);  // 1e-3 grid
+            };
+            const GfVec3d& a = pts.front();
+            const GfVec3d& b = pts.back();
+            const GfVec3d& m = pts[pts.size() / 2];
+            long long ax=q(a[0]),ay=q(a[1]),az=q(a[2]);
+            long long bx=q(b[0]),by=q(b[1]),bz=q(b[2]);
+            // sort endpoints so a reversed coincident edge maps to the same key
+            bool swap = std::tie(ax,ay,az) > std::tie(bx,by,bz);
+            char buf[160];
+            std::snprintf(buf, sizeof buf, "%lld,%lld,%lld|%lld,%lld,%lld|%lld,%lld,%lld",
+                swap?bx:ax, swap?by:ay, swap?bz:az,
+                swap?ax:bx, swap?ay:by, swap?az:bz,
+                q(m[0]), q(m[1]), q(m[2]));
+            return std::string(buf);
+        };
+
+        TopTools_IndexedMapOfShape edgeMap;
+        TopExp::MapShapes(shape, TopAbs_EDGE, edgeMap);
+        for (int ei = 1; ei <= edgeMap.Extent(); ++ei) {
+            const TopoDS_Edge& edge = TopoDS::Edge(edgeMap(ei));
+            if (BRep_Tool::Degenerated(edge)) continue;
+            EdgeRec rec;
+            discretize(edge, rec.pts);
+            if (rec.pts.size() < 2) continue;
+            if (edgeFaceMap.Contains(edge)) {
+                const TopTools_ListOfShape& faces = edgeFaceMap.FindFromKey(edge);
+                if (!faces.IsEmpty()) {
+                    rec.normal = faceNormalAtEdgeMid(
+                        edge, TopoDS::Face(faces.First()), rec.hasNormal);
                 }
             }
+            size_t idx = recs.size();
+            recs.push_back(std::move(rec));
+            groups[keyOf(recs[idx].pts)].push_back(idx);
+        }
+
+        // Tangent if the two owning faces meet at a near-zero dihedral.
+        const double tangentTol = 0.15;  // radians (~8.6 deg)
+        for (const auto& kv : groups) {
+            const std::vector<size_t>& ids = kv.second;
+            const EdgeRec& a = recs[ids[0]];
+            bool tangent = false;
+            if (ids.size() >= 2) {
+                const EdgeRec& b = recs[ids[1]];
+                if (a.hasNormal && b.hasNormal) {
+                    tangent = (a.normal.Angle(b.normal) < tangentTol);
+                }
+            }
+            VtArray<int>& counts = tangent
+                ? result.tangentEdgeCurveVertexCounts
+                : result.edgeCurveVertexCounts;
+            VtArray<GfVec3d>& points = tangent
+                ? result.tangentEdgePoints : result.edgePoints;
+            counts.push_back((int)a.pts.size());
+            for (const auto& p : a.pts) points.push_back(p);
         }
     }
 
@@ -347,6 +445,10 @@ UsdSolidTessellationResult _MergeResults(
             merged.edgeCurveVertexCounts.push_back(c);
         for (const auto& p : r.edgePoints)
             merged.edgePoints.push_back(p);
+        for (const auto& c : r.tangentEdgeCurveVertexCounts)
+            merged.tangentEdgeCurveVertexCounts.push_back(c);
+        for (const auto& p : r.tangentEdgePoints)
+            merged.tangentEdgePoints.push_back(p);
 
         vertOffset += (int)r.points.size();
     }

--- a/pxr/imaging/plugin/hdOcct/tessellator.h
+++ b/pxr/imaging/plugin/hdOcct/tessellator.h
@@ -76,6 +76,13 @@ struct USDSOLIDTESSELLATOR_API UsdSolidTessellationResult {
     /// Per-face source face index within the Brep (for GeomSubset creation).
     VtArray<int> faceSolidFaceIndices;
 
+    /// Discretized B-rep edge polylines, for the optional edge/line display
+    /// mode. \p edgePoints is a flat point array partitioned by
+    /// \p edgeCurveVertexCounts (one count per topological edge), consumed
+    /// exactly like UsdGeomBasisCurves points + curveVertexCounts (type=linear).
+    VtArray<int> edgeCurveVertexCounts;
+    VtArray<GfVec3d> edgePoints;
+
     /// Whether tessellation succeeded.
     bool success = false;
 

--- a/pxr/imaging/plugin/hdOcct/tessellator.h
+++ b/pxr/imaging/plugin/hdOcct/tessellator.h
@@ -80,8 +80,16 @@ struct USDSOLIDTESSELLATOR_API UsdSolidTessellationResult {
     /// mode. \p edgePoints is a flat point array partitioned by
     /// \p edgeCurveVertexCounts (one count per topological edge), consumed
     /// exactly like UsdGeomBasisCurves points + curveVertexCounts (type=linear).
+    /// These are the SHARP / feature edges (and open boundary edges).
     VtArray<int> edgeCurveVertexCounts;
     VtArray<GfVec3d> edgePoints;
+
+    /// Tangent (smooth, G1-continuous) edges — e.g. fillet<->face transitions —
+    /// classified by the dihedral angle between the two adjacent faces. Emitted
+    /// as a separate, independently toggleable curve set (CAD "tangent edges").
+    /// Same flat-array-partitioned-by-counts layout as the sharp edges above.
+    VtArray<int> tangentEdgeCurveVertexCounts;
+    VtArray<GfVec3d> tangentEdgePoints;
 
     /// Whether tessellation succeeded.
     bool success = false;

--- a/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation.py
+++ b/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation.py
@@ -58,6 +58,13 @@ PRIM_PATHS = {
     'testPlaneWithHole.usda': '/World/PlaneWithHole',
     'testSphere.usda': '/World/Sphere',
     'testTwoBoxes.usda': '/World/TwoBoxes',
+    'testAnalyticPlane.usda': '/World/AnPlane',
+    'testAnalyticCylinder.usda': '/World/AnalyticCyl',
+    'testAnalyticCone.usda': '/World/AnCone',
+    'testAnalyticSphere.usda': '/World/AnSphere',
+    'testAnalyticTorus.usda': '/World/AnTorus',
+    'testAnalyticCylinderEdges.usda': '/World/CylEdge',
+    'testAnalyticConeEdges.usda': '/World/ConeEdge',
 }
 
 # Closed solids: signed volume must be positive (outward winding).
@@ -71,6 +78,26 @@ CLOSED_SOLIDS = [
     'testSphere.usda',
     'testTwoBoxes.usda',
 ]
+
+# Analytic-surface fixtures -> (expected meshed area, absolute tolerance).
+#
+# These exercise the analytic surface readers: each face is built from its
+# schema parameters (origin/axis/refDirection + radius/semiAngle/...) rather
+# than NURBS control points. The five surface types use the authored curveUv
+# (pcurve) trimming path; the *Edges fixtures additionally exercise the
+# analytic 3D-edge path (analytic surface trimmed by analytic circle/line
+# curves with no authored curveUv). Areas are geometric and independent of
+# the OCCT meshing algorithm; curved surfaces mesh slightly under their true
+# area (chord-height deflection), so the tolerance permits a small undershoot.
+ANALYTIC_AREA_FIXTURES = {
+    'testAnalyticPlane.usda':         (12.0, 0.5),
+    'testAnalyticCylinder.usda':      (2.0 * math.pi * 3.0 * 5.0, 2.0),
+    'testAnalyticCone.usda':          (25.28, 1.0),
+    'testAnalyticSphere.usda':        (59.98, 2.0),
+    'testAnalyticTorus.usda':         (203.22, 6.0),
+    'testAnalyticCylinderEdges.usda': (70.686, 2.5),
+    'testAnalyticConeEdges.usda':     (25.28, 1.5),
+}
 
 
 def _get_fixtures_dir():
@@ -363,6 +390,49 @@ class TestTessellationErrorHandling(unittest.TestCase):
         if os.path.exists(output_path):
             os.unlink(output_path)
         self.assertNotEqual(rc, 0)
+
+
+class TestAnalyticSurfaceArea(unittest.TestCase):
+    """Analytic surfaces tessellate to their exact geometric area.
+
+    Each analytic surface type (plane, cylinder, cone, sphere, torus) is
+    constructed from its schema parameters rather than from NURBS control
+    points, and trimmed via the authored curveUv (pcurve) path. The *Edges
+    fixtures additionally exercise the analytic 3D-edge path: an analytic
+    surface trimmed by analytic circle/line curves with no authored curveUv,
+    where each edge's pcurve is projected onto the surface. Areas are
+    geometry-based and independent of the OCCT meshing algorithm.
+    """
+
+    def _check_area(self, fixture_name):
+        expected, tol = ANALYTIC_AREA_FIXTURES[fixture_name]
+        stage = _tessellate_fixture(fixture_name)
+        area = _total_surface_area(stage)
+        self.assertGreater(area, 0.0, f"{fixture_name}: empty mesh")
+        self.assertAlmostEqual(
+            area, expected, delta=tol,
+            msg=f"{fixture_name}: area {area:.3f} != {expected:.3f}")
+
+    def test_AnalyticPlane(self):
+        self._check_area('testAnalyticPlane.usda')
+
+    def test_AnalyticCylinder(self):
+        self._check_area('testAnalyticCylinder.usda')
+
+    def test_AnalyticCone(self):
+        self._check_area('testAnalyticCone.usda')
+
+    def test_AnalyticSphere(self):
+        self._check_area('testAnalyticSphere.usda')
+
+    def test_AnalyticTorus(self):
+        self._check_area('testAnalyticTorus.usda')
+
+    def test_AnalyticCylinderEdges(self):
+        self._check_area('testAnalyticCylinderEdges.usda')
+
+    def test_AnalyticConeEdges(self):
+        self._check_area('testAnalyticConeEdges.usda')
 
 
 if __name__ == '__main__':

--- a/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation/fixtures/testAnalyticCone.usda
+++ b/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation/fixtures/testAnalyticCone.usda
@@ -1,0 +1,53 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+    upAxis = "Z"
+)
+
+def Xform "World"
+{
+    def BrepArray "AnCone" (
+        prepend apiSchemas = ["BrepPointAPI:vertexPoint", "BrepCurve3dNurbAPI:edge3dNurb", "BrepCurveUvNurbAPI", "BrepSurfaceConeAPI"]
+    )
+    {
+        uniform uint[] brep:regionCount = [1]
+        uniform uint[] region:shellCount = [1]
+        uniform token[] region:type = ["solidRegion"]
+        uniform uint[] shell:faceuseCount = [2]
+        uniform uint[] shell:wireEdgeCount = [0]
+        uniform token[] shell:pointType = ["none"]
+        uniform uint[] faceuse:faceIndex = [0, 0]
+        uniform token[] faceuse:orientationType = ["same", "opposite"]
+        uniform uint[] face:loopCount = [1]
+        uniform token[] face:surfaceType = ["BrepSurfaceConeAPI"]
+        uniform token[] face:trimType = ["general"]
+        uniform double2[] face:range = [(0, 1), (4.712388980385, 5)]
+        uniform uint[] loop:edgeuseCount = [4]
+        uniform uint[] loop:vertexIndex = [0]
+        uniform uint[] edgeuse:edgeIndex = [0, 1, 2, 3]
+        uniform token[] edgeuse:orientationType = ["same", "same", "same", "same"]
+        uniform uint[] edgeuse:nextRadialEUIndex = [0, 1, 2, 3]
+        uniform token[] edgeuse:thisRadialEntryType = ["topEntry", "topEntry", "topEntry", "topEntry"]
+        uniform token[] edge:curveType = ["BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI"]
+        uniform double[] edge:range = [0, 1, 0, 1, 0, 1, 0, 1]
+        uniform int2[] edge:vertexIndices = [(0,1), (1,2), (2,3), (3,0)]
+        uniform token[] vertex:pointType = ["BrepPointAPI", "BrepPointAPI", "BrepPointAPI", "BrepPointAPI"]
+        uniform point3d[] brep:vertexPoint:point:position = [(0.4472135955, 0, 0.894427191), (-0.0, -0.4472135955, 0.894427191), (-0.0, -2.2360679775, 4.472135955), (2.2360679775, 0, 4.472135955)]
+        uniform point3d[] brep:surface:cone:origin = [(0, 0, 0)]
+        uniform vector3d[] brep:surface:cone:axis = [(0, 0, 1)]
+        uniform vector3d[] brep:surface:cone:refDirection = [(1, 0, 0)]
+        uniform double[] brep:surface:cone:radius = [0]
+        uniform double[] brep:surface:cone:semiAngle = [0.463647609001]
+        uniform uint[] brep:edge3dNurb:curve3d:nurb:order = [2, 2, 2, 2]
+        uniform uint[] brep:edge3dNurb:curve3d:nurb:vertexCount = [2, 2, 2, 2]
+        uniform double[] brep:edge3dNurb:curve3d:nurb:knots = [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]
+        uniform point3d[] brep:edge3dNurb:curve3d:nurb:controlVertices = [(0.4472135955, 0, 0.894427191), (-0.0, -0.4472135955, 0.894427191), (-0.0, -0.4472135955, 0.894427191), (-0.0, -2.2360679775, 4.472135955), (-0.0, -2.2360679775, 4.472135955), (2.2360679775, 0, 4.472135955), (2.2360679775, 0, 4.472135955), (0.4472135955, 0, 0.894427191)]
+        uniform double[] brep:edge3dNurb:curve3d:nurb:weights = [1, 1, 1, 1, 1, 1, 1, 1]
+        uniform uint[] brep:curveUv:nurb:order = [2, 2, 2, 2]
+        uniform uint[] brep:curveUv:nurb:vertexCount = [2, 2, 2, 2]
+        uniform double[] brep:curveUv:nurb:knots = [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]
+        uniform double2[] brep:curveUv:nurb:controlVertices = [(0, 1), (4.712388980385, 1), (4.712388980385, 1), (4.712388980385, 5), (4.712388980385, 5), (0, 5), (0, 5), (0, 1)]
+        uniform double[] brep:curveUv:nurb:weights = [1, 1, 1, 1, 1, 1, 1, 1]
+        uniform double[] brep:intersectTol3d = [1e-6]
+    }
+}

--- a/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation/fixtures/testAnalyticConeEdges.usda
+++ b/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation/fixtures/testAnalyticConeEdges.usda
@@ -1,0 +1,49 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+    upAxis = "Z"
+)
+
+def Xform "World"
+{
+    def BrepArray "ConeEdge" (
+        prepend apiSchemas = ["BrepPointAPI:vertexPoint", "BrepCurve3dCircleAPI:edge3dCircle", "BrepCurve3dLineAPI:edge3dLine", "BrepSurfaceConeAPI"]
+    )
+    {
+        uniform uint[] brep:regionCount = [1]
+        uniform uint[] region:shellCount = [1]
+        uniform token[] region:type = ["solidRegion"]
+        uniform uint[] shell:faceuseCount = [2]
+        uniform uint[] shell:wireEdgeCount = [0]
+        uniform token[] shell:pointType = ["none"]
+        uniform uint[] faceuse:faceIndex = [0, 0]
+        uniform token[] faceuse:orientationType = ["same", "opposite"]
+        uniform uint[] face:loopCount = [1]
+        uniform token[] face:surfaceType = ["BrepSurfaceConeAPI"]
+        uniform token[] face:trimType = ["general"]
+        uniform double2[] face:range = [(0, 1), (4.712388980385, 5)]
+        uniform uint[] loop:edgeuseCount = [4]
+        uniform uint[] loop:vertexIndex = [0]
+        uniform uint[] edgeuse:edgeIndex = [0, 1, 2, 3]
+        uniform token[] edgeuse:orientationType = ["same", "same", "opposite", "opposite"]
+        uniform uint[] edgeuse:nextRadialEUIndex = [0, 1, 2, 3]
+        uniform token[] edgeuse:thisRadialEntryType = ["topEntry", "topEntry", "topEntry", "topEntry"]
+        uniform token[] edge:curveType = ["BrepCurve3dCircleAPI", "BrepCurve3dLineAPI", "BrepCurve3dCircleAPI", "BrepCurve3dLineAPI"]
+        uniform double[] edge:range = [0, 4.712388980385, 0, 4, 0, 4.712388980385, 0, 4]
+        uniform int2[] edge:vertexIndices = [(0,1), (1,2), (3,2), (0,3)]
+        uniform token[] vertex:pointType = ["BrepPointAPI", "BrepPointAPI", "BrepPointAPI", "BrepPointAPI"]
+        uniform point3d[] brep:vertexPoint:point:position = [(0.4472135955, 0, 0.894427191), (-0.0, -0.4472135955, 0.894427191), (-0.0, -2.2360679775, 4.472135955), (2.2360679775, 0, 4.472135955)]
+        uniform point3d[] brep:surface:cone:origin = [(0, 0, 0)]
+        uniform vector3d[] brep:surface:cone:axis = [(0, 0, 1)]
+        uniform vector3d[] brep:surface:cone:refDirection = [(1, 0, 0)]
+        uniform double[] brep:surface:cone:radius = [0]
+        uniform double[] brep:surface:cone:semiAngle = [0.463647609001]
+        uniform point3d[] brep:edge3dCircle:curve3d:circle:center = [(0, 0, 0.894427191), (0, 0, 4.472135955)]
+        uniform vector3d[] brep:edge3dCircle:curve3d:circle:axis = [(0, 0, 1), (0, 0, 1)]
+        uniform vector3d[] brep:edge3dCircle:curve3d:circle:refDirection = [(1, 0, 0), (1, 0, 0)]
+        uniform double[] brep:edge3dCircle:curve3d:circle:radius = [0.4472135955, 2.2360679775]
+        uniform point3d[] brep:edge3dLine:curve3d:line:origin = [(-0.0, -0.4472135955, 0.894427191), (0.4472135955, 0, 0.894427191)]
+        uniform vector3d[] brep:edge3dLine:curve3d:line:direction = [(-0.0, -0.4472135955, 0.894427191), (0.4472135955, 0, 0.894427191)]
+        uniform double[] brep:intersectTol3d = [1e-6]
+    }
+}

--- a/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation/fixtures/testAnalyticCylinder.usda
+++ b/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation/fixtures/testAnalyticCylinder.usda
@@ -1,0 +1,52 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+    upAxis = "Z"
+)
+
+def Xform "World"
+{
+    def BrepArray "AnalyticCyl" (
+        prepend apiSchemas = ["BrepPointAPI:vertexPoint", "BrepCurve3dNurbAPI:edge3dNurb", "BrepCurveUvNurbAPI", "BrepSurfaceCylinderAPI"]
+    )
+    {
+        uniform uint[] brep:regionCount = [1]
+        uniform uint[] region:shellCount = [1]
+        uniform token[] region:type = ["solidRegion"]
+        uniform uint[] shell:faceuseCount = [2]
+        uniform uint[] shell:wireEdgeCount = [0]
+        uniform token[] shell:pointType = ["none"]
+        uniform uint[] faceuse:faceIndex = [0, 0]
+        uniform token[] faceuse:orientationType = ["same", "opposite"]
+        uniform uint[] face:loopCount = [1]
+        uniform token[] face:surfaceType = ["BrepSurfaceCylinderAPI"]
+        uniform token[] face:trimType = ["general"]
+        uniform double2[] face:range = [(0, 0), (6.2831853072, 5)]
+        uniform uint[] loop:edgeuseCount = [4]
+        uniform uint[] loop:vertexIndex = [0]
+        uniform uint[] edgeuse:edgeIndex = [0, 1, 2, 3]
+        uniform token[] edgeuse:orientationType = ["same", "same", "same", "same"]
+        uniform uint[] edgeuse:nextRadialEUIndex = [0, 1, 2, 3]
+        uniform token[] edgeuse:thisRadialEntryType = ["topEntry", "topEntry", "topEntry", "topEntry"]
+        uniform token[] edge:curveType = ["BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI"]
+        uniform double[] edge:range = [0, 6.2831853072, 0, 1, 0, 6.2831853072, 0, 1]
+        uniform int2[] edge:vertexIndices = [(0,0), (0,1), (1,1), (1,0)]
+        uniform token[] vertex:pointType = ["BrepPointAPI", "BrepPointAPI"]
+        uniform point3d[] brep:vertexPoint:point:position = [(3, 0, 0), (3, 0, 5)]
+        uniform point3d[] brep:surface:cylinder:origin = [(0, 0, 0)]
+        uniform vector3d[] brep:surface:cylinder:axis = [(0, 0, 1)]
+        uniform vector3d[] brep:surface:cylinder:refDirection = [(1, 0, 0)]
+        uniform double[] brep:surface:cylinder:radius = [3]
+        uniform uint[] brep:edge3dNurb:curve3d:nurb:order = [3, 2, 3, 2]
+        uniform uint[] brep:edge3dNurb:curve3d:nurb:vertexCount = [7, 2, 7, 2]
+        uniform double[] brep:edge3dNurb:curve3d:nurb:knots = [0, 0, 0, 2.0943951024, 2.0943951024, 4.1887902048, 4.1887902048, 6.2831853072, 6.2831853072, 6.2831853072, 0, 0, 1, 1, 0, 0, 0, 2.0943951024, 2.0943951024, 4.1887902048, 4.1887902048, 6.2831853072, 6.2831853072, 6.2831853072, 0, 0, 1, 1]
+        uniform point3d[] brep:edge3dNurb:curve3d:nurb:controlVertices = [(3, 0, 0), (3, 5.1961524227, 0), (-1.5, 2.5980762114, 0), (-6.0, 0.0, 0), (-1.5, -2.5980762114, 0), (3, -5.1961524227, 0), (3, 0, 0), (3, 0, 0), (3, 0, 5), (3, 0, 5), (3, 5.1961524227, 5), (-1.5, 2.5980762114, 5), (-6.0, 0.0, 5), (-1.5, -2.5980762114, 5), (3, -5.1961524227, 5), (3, 0, 5), (3, 0, 5), (3, 0, 0)]
+        uniform double[] brep:edge3dNurb:curve3d:nurb:weights = [1, 0.5, 1, 0.5, 1, 0.5, 1, 1, 1, 1, 0.5, 1, 0.5, 1, 0.5, 1, 1, 1]
+        uniform uint[] brep:curveUv:nurb:order = [2, 2, 2, 2]
+        uniform uint[] brep:curveUv:nurb:vertexCount = [2, 2, 2, 2]
+        uniform double[] brep:curveUv:nurb:knots = [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]
+        uniform double2[] brep:curveUv:nurb:controlVertices = [(0, 0), (6.2831853072, 0), (6.2831853072, 0), (6.2831853072, 5), (6.2831853072, 5), (0, 5), (0, 5), (0, 0)]
+        uniform double[] brep:curveUv:nurb:weights = [1, 1, 1, 1, 1, 1, 1, 1]
+        uniform double[] brep:intersectTol3d = [1e-6]
+    }
+}

--- a/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation/fixtures/testAnalyticCylinderEdges.usda
+++ b/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation/fixtures/testAnalyticCylinderEdges.usda
@@ -1,0 +1,48 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+    upAxis = "Z"
+)
+
+def Xform "World"
+{
+    def BrepArray "CylEdge" (
+        prepend apiSchemas = ["BrepPointAPI:vertexPoint", "BrepCurve3dCircleAPI:edge3dCircle", "BrepCurve3dLineAPI:edge3dLine", "BrepSurfaceCylinderAPI"]
+    )
+    {
+        uniform uint[] brep:regionCount = [1]
+        uniform uint[] region:shellCount = [1]
+        uniform token[] region:type = ["solidRegion"]
+        uniform uint[] shell:faceuseCount = [2]
+        uniform uint[] shell:wireEdgeCount = [0]
+        uniform token[] shell:pointType = ["none"]
+        uniform uint[] faceuse:faceIndex = [0, 0]
+        uniform token[] faceuse:orientationType = ["same", "opposite"]
+        uniform uint[] face:loopCount = [1]
+        uniform token[] face:surfaceType = ["BrepSurfaceCylinderAPI"]
+        uniform token[] face:trimType = ["general"]
+        uniform double2[] face:range = [(0, 0), (4.712388980385, 5)]
+        uniform uint[] loop:edgeuseCount = [4]
+        uniform uint[] loop:vertexIndex = [0]
+        uniform uint[] edgeuse:edgeIndex = [0, 1, 2, 3]
+        uniform token[] edgeuse:orientationType = ["same", "same", "opposite", "opposite"]
+        uniform uint[] edgeuse:nextRadialEUIndex = [0, 1, 2, 3]
+        uniform token[] edgeuse:thisRadialEntryType = ["topEntry", "topEntry", "topEntry", "topEntry"]
+        uniform token[] edge:curveType = ["BrepCurve3dCircleAPI", "BrepCurve3dLineAPI", "BrepCurve3dCircleAPI", "BrepCurve3dLineAPI"]
+        uniform double[] edge:range = [0, 4.712388980385, 0, 5, 0, 4.712388980385, 0, 5]
+        uniform int2[] edge:vertexIndices = [(0,1), (1,2), (3,2), (0,3)]
+        uniform token[] vertex:pointType = ["BrepPointAPI", "BrepPointAPI", "BrepPointAPI", "BrepPointAPI"]
+        uniform point3d[] brep:vertexPoint:point:position = [(3, 0, 0), (-0.0, -3, 0), (-0.0, -3, 5), (3, 0, 5)]
+        uniform point3d[] brep:surface:cylinder:origin = [(0, 0, 0)]
+        uniform vector3d[] brep:surface:cylinder:axis = [(0, 0, 1)]
+        uniform vector3d[] brep:surface:cylinder:refDirection = [(1, 0, 0)]
+        uniform double[] brep:surface:cylinder:radius = [3]
+        uniform point3d[] brep:edge3dCircle:curve3d:circle:center = [(0, 0, 0), (0, 0, 5)]
+        uniform vector3d[] brep:edge3dCircle:curve3d:circle:axis = [(0, 0, 1), (0, 0, 1)]
+        uniform vector3d[] brep:edge3dCircle:curve3d:circle:refDirection = [(1, 0, 0), (1, 0, 0)]
+        uniform double[] brep:edge3dCircle:curve3d:circle:radius = [3, 3]
+        uniform point3d[] brep:edge3dLine:curve3d:line:origin = [(-0.0, -3, 0), (3, 0, 0)]
+        uniform vector3d[] brep:edge3dLine:curve3d:line:direction = [(0, 0, 1), (0, 0, 1)]
+        uniform double[] brep:intersectTol3d = [1e-6]
+    }
+}

--- a/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation/fixtures/testAnalyticPlane.usda
+++ b/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation/fixtures/testAnalyticPlane.usda
@@ -1,0 +1,51 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+    upAxis = "Z"
+)
+
+def Xform "World"
+{
+    def BrepArray "AnPlane" (
+        prepend apiSchemas = ["BrepPointAPI:vertexPoint", "BrepCurve3dNurbAPI:edge3dNurb", "BrepCurveUvNurbAPI", "BrepSurfacePlaneAPI"]
+    )
+    {
+        uniform uint[] brep:regionCount = [1]
+        uniform uint[] region:shellCount = [1]
+        uniform token[] region:type = ["solidRegion"]
+        uniform uint[] shell:faceuseCount = [2]
+        uniform uint[] shell:wireEdgeCount = [0]
+        uniform token[] shell:pointType = ["none"]
+        uniform uint[] faceuse:faceIndex = [0, 0]
+        uniform token[] faceuse:orientationType = ["same", "opposite"]
+        uniform uint[] face:loopCount = [1]
+        uniform token[] face:surfaceType = ["BrepSurfacePlaneAPI"]
+        uniform token[] face:trimType = ["general"]
+        uniform double2[] face:range = [(0, 0), (4, 3)]
+        uniform uint[] loop:edgeuseCount = [4]
+        uniform uint[] loop:vertexIndex = [0]
+        uniform uint[] edgeuse:edgeIndex = [0, 1, 2, 3]
+        uniform token[] edgeuse:orientationType = ["same", "same", "same", "same"]
+        uniform uint[] edgeuse:nextRadialEUIndex = [0, 1, 2, 3]
+        uniform token[] edgeuse:thisRadialEntryType = ["topEntry", "topEntry", "topEntry", "topEntry"]
+        uniform token[] edge:curveType = ["BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI"]
+        uniform double[] edge:range = [0, 1, 0, 1, 0, 1, 0, 1]
+        uniform int2[] edge:vertexIndices = [(0,1), (1,2), (2,3), (3,0)]
+        uniform token[] vertex:pointType = ["BrepPointAPI", "BrepPointAPI", "BrepPointAPI", "BrepPointAPI"]
+        uniform point3d[] brep:vertexPoint:point:position = [(0, 0, 0), (4, 0, 0), (4, 3, 0), (0, 3, 0)]
+        uniform point3d[] brep:surface:plane:origin = [(0, 0, 0)]
+        uniform vector3d[] brep:surface:plane:axis = [(0, 0, 1)]
+        uniform vector3d[] brep:surface:plane:refDirection = [(1, 0, 0)]
+        uniform uint[] brep:edge3dNurb:curve3d:nurb:order = [2, 2, 2, 2]
+        uniform uint[] brep:edge3dNurb:curve3d:nurb:vertexCount = [2, 2, 2, 2]
+        uniform double[] brep:edge3dNurb:curve3d:nurb:knots = [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]
+        uniform point3d[] brep:edge3dNurb:curve3d:nurb:controlVertices = [(0, 0, 0), (4, 0, 0), (4, 0, 0), (4, 3, 0), (4, 3, 0), (0, 3, 0), (0, 3, 0), (0, 0, 0)]
+        uniform double[] brep:edge3dNurb:curve3d:nurb:weights = [1, 1, 1, 1, 1, 1, 1, 1]
+        uniform uint[] brep:curveUv:nurb:order = [2, 2, 2, 2]
+        uniform uint[] brep:curveUv:nurb:vertexCount = [2, 2, 2, 2]
+        uniform double[] brep:curveUv:nurb:knots = [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]
+        uniform double2[] brep:curveUv:nurb:controlVertices = [(0, 0), (4, 0), (4, 0), (4, 3), (4, 3), (0, 3), (0, 3), (0, 0)]
+        uniform double[] brep:curveUv:nurb:weights = [1, 1, 1, 1, 1, 1, 1, 1]
+        uniform double[] brep:intersectTol3d = [1e-6]
+    }
+}

--- a/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation/fixtures/testAnalyticSphere.usda
+++ b/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation/fixtures/testAnalyticSphere.usda
@@ -1,0 +1,52 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+    upAxis = "Z"
+)
+
+def Xform "World"
+{
+    def BrepArray "AnSphere" (
+        prepend apiSchemas = ["BrepPointAPI:vertexPoint", "BrepCurve3dNurbAPI:edge3dNurb", "BrepCurveUvNurbAPI", "BrepSurfaceSphereAPI"]
+    )
+    {
+        uniform uint[] brep:regionCount = [1]
+        uniform uint[] region:shellCount = [1]
+        uniform token[] region:type = ["solidRegion"]
+        uniform uint[] shell:faceuseCount = [2]
+        uniform uint[] shell:wireEdgeCount = [0]
+        uniform token[] shell:pointType = ["none"]
+        uniform uint[] faceuse:faceIndex = [0, 0]
+        uniform token[] faceuse:orientationType = ["same", "opposite"]
+        uniform uint[] face:loopCount = [1]
+        uniform token[] face:surfaceType = ["BrepSurfaceSphereAPI"]
+        uniform token[] face:trimType = ["general"]
+        uniform double2[] face:range = [(0, -0.785398163397), (4.712388980385, 0.785398163397)]
+        uniform uint[] loop:edgeuseCount = [4]
+        uniform uint[] loop:vertexIndex = [0]
+        uniform uint[] edgeuse:edgeIndex = [0, 1, 2, 3]
+        uniform token[] edgeuse:orientationType = ["same", "same", "same", "same"]
+        uniform uint[] edgeuse:nextRadialEUIndex = [0, 1, 2, 3]
+        uniform token[] edgeuse:thisRadialEntryType = ["topEntry", "topEntry", "topEntry", "topEntry"]
+        uniform token[] edge:curveType = ["BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI"]
+        uniform double[] edge:range = [0, 1, 0, 1, 0, 1, 0, 1]
+        uniform int2[] edge:vertexIndices = [(0,1), (1,2), (2,3), (3,0)]
+        uniform token[] vertex:pointType = ["BrepPointAPI", "BrepPointAPI", "BrepPointAPI", "BrepPointAPI"]
+        uniform point3d[] brep:vertexPoint:point:position = [(2.12132034356, 0, -2.12132034356), (-0.0, -2.12132034356, -2.12132034356), (-0.0, -2.12132034356, 2.12132034356), (2.12132034356, 0, 2.12132034356)]
+        uniform point3d[] brep:surface:sphere:center = [(0, 0, 0)]
+        uniform vector3d[] brep:surface:sphere:axis = [(0, 0, 1)]
+        uniform vector3d[] brep:surface:sphere:refDirection = [(1, 0, 0)]
+        uniform double[] brep:surface:sphere:radius = [3]
+        uniform uint[] brep:edge3dNurb:curve3d:nurb:order = [2, 2, 2, 2]
+        uniform uint[] brep:edge3dNurb:curve3d:nurb:vertexCount = [2, 2, 2, 2]
+        uniform double[] brep:edge3dNurb:curve3d:nurb:knots = [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]
+        uniform point3d[] brep:edge3dNurb:curve3d:nurb:controlVertices = [(2.12132034356, 0, -2.12132034356), (-0.0, -2.12132034356, -2.12132034356), (-0.0, -2.12132034356, -2.12132034356), (-0.0, -2.12132034356, 2.12132034356), (-0.0, -2.12132034356, 2.12132034356), (2.12132034356, 0, 2.12132034356), (2.12132034356, 0, 2.12132034356), (2.12132034356, 0, -2.12132034356)]
+        uniform double[] brep:edge3dNurb:curve3d:nurb:weights = [1, 1, 1, 1, 1, 1, 1, 1]
+        uniform uint[] brep:curveUv:nurb:order = [2, 2, 2, 2]
+        uniform uint[] brep:curveUv:nurb:vertexCount = [2, 2, 2, 2]
+        uniform double[] brep:curveUv:nurb:knots = [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]
+        uniform double2[] brep:curveUv:nurb:controlVertices = [(0, -0.785398163397), (4.712388980385, -0.785398163397), (4.712388980385, -0.785398163397), (4.712388980385, 0.785398163397), (4.712388980385, 0.785398163397), (0, 0.785398163397), (0, 0.785398163397), (0, -0.785398163397)]
+        uniform double[] brep:curveUv:nurb:weights = [1, 1, 1, 1, 1, 1, 1, 1]
+        uniform double[] brep:intersectTol3d = [1e-6]
+    }
+}

--- a/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation/fixtures/testAnalyticTorus.usda
+++ b/pxr/imaging/plugin/hdOcct/testenv/testUsdSolidTessellation/fixtures/testAnalyticTorus.usda
@@ -1,0 +1,53 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+    upAxis = "Z"
+)
+
+def Xform "World"
+{
+    def BrepArray "AnTorus" (
+        prepend apiSchemas = ["BrepPointAPI:vertexPoint", "BrepCurve3dNurbAPI:edge3dNurb", "BrepCurveUvNurbAPI", "BrepSurfaceTorusAPI"]
+    )
+    {
+        uniform uint[] brep:regionCount = [1]
+        uniform uint[] region:shellCount = [1]
+        uniform token[] region:type = ["solidRegion"]
+        uniform uint[] shell:faceuseCount = [2]
+        uniform uint[] shell:wireEdgeCount = [0]
+        uniform token[] shell:pointType = ["none"]
+        uniform uint[] faceuse:faceIndex = [0, 0]
+        uniform token[] faceuse:orientationType = ["same", "opposite"]
+        uniform uint[] face:loopCount = [1]
+        uniform token[] face:surfaceType = ["BrepSurfaceTorusAPI"]
+        uniform token[] face:trimType = ["general"]
+        uniform double2[] face:range = [(0, 0), (4.712388980385, 4.712388980385)]
+        uniform uint[] loop:edgeuseCount = [4]
+        uniform uint[] loop:vertexIndex = [0]
+        uniform uint[] edgeuse:edgeIndex = [0, 1, 2, 3]
+        uniform token[] edgeuse:orientationType = ["same", "same", "same", "same"]
+        uniform uint[] edgeuse:nextRadialEUIndex = [0, 1, 2, 3]
+        uniform token[] edgeuse:thisRadialEntryType = ["topEntry", "topEntry", "topEntry", "topEntry"]
+        uniform token[] edge:curveType = ["BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI", "BrepCurve3dNurbAPI"]
+        uniform double[] edge:range = [0, 1, 0, 1, 0, 1, 0, 1]
+        uniform int2[] edge:vertexIndices = [(0,1), (1,2), (2,3), (3,0)]
+        uniform token[] vertex:pointType = ["BrepPointAPI", "BrepPointAPI", "BrepPointAPI", "BrepPointAPI"]
+        uniform point3d[] brep:vertexPoint:point:position = [(7, 0, 0), (-0.0, -7, 0), (-0.0, -5, -2), (5, 0, -2)]
+        uniform point3d[] brep:surface:torus:origin = [(0, 0, 0)]
+        uniform vector3d[] brep:surface:torus:axis = [(0, 0, 1)]
+        uniform vector3d[] brep:surface:torus:refDirection = [(1, 0, 0)]
+        uniform double[] brep:surface:torus:majorRadius = [5]
+        uniform double[] brep:surface:torus:minorRadius = [2]
+        uniform uint[] brep:edge3dNurb:curve3d:nurb:order = [2, 2, 2, 2]
+        uniform uint[] brep:edge3dNurb:curve3d:nurb:vertexCount = [2, 2, 2, 2]
+        uniform double[] brep:edge3dNurb:curve3d:nurb:knots = [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]
+        uniform point3d[] brep:edge3dNurb:curve3d:nurb:controlVertices = [(7, 0, 0), (-0.0, -7, 0), (-0.0, -7, 0), (-0.0, -5, -2), (-0.0, -5, -2), (5, 0, -2), (5, 0, -2), (7, 0, 0)]
+        uniform double[] brep:edge3dNurb:curve3d:nurb:weights = [1, 1, 1, 1, 1, 1, 1, 1]
+        uniform uint[] brep:curveUv:nurb:order = [2, 2, 2, 2]
+        uniform uint[] brep:curveUv:nurb:vertexCount = [2, 2, 2, 2]
+        uniform double[] brep:curveUv:nurb:knots = [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]
+        uniform double2[] brep:curveUv:nurb:controlVertices = [(0, 0), (4.712388980385, 0), (4.712388980385, 0), (4.712388980385, 4.712388980385), (4.712388980385, 4.712388980385), (0, 4.712388980385), (0, 4.712388980385), (0, 0)]
+        uniform double[] brep:curveUv:nurb:weights = [1, 1, 1, 1, 1, 1, 1, 1]
+        uniform double[] brep:intersectTol3d = [1e-6]
+    }
+}


### PR DESCRIPTION
## Analytic curve readers + 3D-edge trimming for hdOcct BrepArray tessellation

Completes UsdSolid analytic-geometry support in the OCCT reference tessellator. The analytic **surface** readers already exist in the base branch; this adds the analytic **curve** side and the 3D-edge trim path, plus fixtures and tests.

### What this adds
- **Analytic 3D-curve readers** — `BrepCurve3dLineAPI` / `BrepCurve3dCircleAPI` / `BrepCurve3dEllipseAPI` → `Geom_Line` / `Geom_Circle` / `Geom_Ellipse` (built from `gp_Ax2` + radii), bounded by the authored `edge:range`.
- **Analytic 3D-edge trim path** — for analytic (elementary) surfaces authored with no `curveUv`, each face is trimmed by its analytic 3D edges, with an exact pcurve projected onto the surface (`GeomProjLib::Curve2d` + `BRep_Builder::UpdateEdge`). Curved analytic faces (cylinder/cone) need this explicit pcurve to mesh — `ShapeFix` alone leaves them empty.
- **Gating + robustness** — the new path runs only for elementary surfaces (plane/cylinder/cone/sphere/torus); NURBS faces keep their exact legacy behaviour (existing fixtures unchanged). All OCCT construction is wrapped in `try/catch (Standard_Failure)` so malformed producer data can never crash the tessellator.
- **7 analytic fixtures + area-assertion tests** (`TestAnalyticSurfaceArea`) — plane/cylinder/cone/sphere/torus via the curveUv path, plus cylinder/cone via the analytic 3D-edge path. Areas are geometric (OCCT-meshing-independent) and checked against independently-derived analytic formulas.

### Verification
- `testUsdSolidTessellation`: **33/33 pass** (26 existing + 7 new analytic).
- Areas within tessellation tolerance: plane 12.00, cylinder 94.03/94.25, cone 25.12/25.28, sphere 58.78/59.98, torus 201.9/203.2; 3D-edge cylinder 70.5/70.69, 3D-edge cone 25.1/25.28.
- Real SmConnect `intersect_cone_box.usda` (cone + plane, analytic circle/line edges, no curveUv) tessellates.

### Known limitation
A sphere/torus face bounded by a great-circle/cap wire that **encloses a pole**, authored with no `curveUv` (the SmConnect double-edgeuse encoding), cannot be bound by OCCT from the wire alone; it is **cleanly skipped** (no crash, no garbage geometry). The curveUv path covers all five surface types including spheres (verified). Tracked as a follow-up.

### ⚠️ Branch topology — needs your decision
Based on `feature/hdocct-brep-edges` (#65), not `feature/hdocct-tessellator` (#62), because the analytic **surface** readers and the "edges from face triangulation" tessellation refactor that this builds on currently live on the edge branch; the `#62` branch (`f3cae81`) is behind and produces empty analytic meshes. Recommend consolidating the analytic surface + curve work onto the tessellator PR (#62) before upstreaming to AOUSD. Opened as a draft for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
